### PR TITLE
Add pycache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ test/tests/*/output
 .litani_cache_dir
 doc/index.html
 doc/litani-flow.svg
+__pycache__/


### PR DESCRIPTION
Add python cache `__pycache__` to the `.gitignore` file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
