### PR TITLE
Exit with zero even when pipelines fail by default

### DIFF
--- a/litani
+++ b/litani
@@ -197,9 +197,9 @@ def get_args():
             "metavar": "F",
             "help": "periodically write JSON representation of the run"
     }, {
-            "flags": ["--exit-zero-on-fail"],
+            "flags": ["--fail-on-pipeline-failure"],
             "action": "store_true",
-            "help": "exit with return code 0 even if some pipelines failed"
+            "help": "exit with a non-zero return code if some pipelines failed"
     }]:
         flags = arg.pop("flags")
         run_build_pars.add_argument(*flags, **arg)
@@ -637,10 +637,10 @@ def run_build(args):
         with litani.atomic_write(args.out_file) as handle:
             print(json.dumps(run, indent=2), file=handle)
 
-    if args.exit_zero_on_fail:
-        sys.exit(0)
+    if args.fail_on_pipeline_failure:
+        sys.exit(1 if proc.returncode else 0)
 
-    sys.exit(1 if proc.returncode else 0)
+    sys.exit(0)
 
 
 def exec_job(args):


### PR DESCRIPTION
This commit changes Litani's default behaviour such that the return code
does not depend on the pipelines' success. Litani will exit with a
return code of zero even when one or more ninja jobs fail. The old
behaviour, where a single ninja job failing would make litani exit with
1, can be restored with `--abnormal-exit-on-fail`.

This change is due to litani having an out-of-band medium for
communicating the status of pipelines (the result.json file), which is
vastly more expressive than a return code. Hence, the return code is
reserved for communicating fatal errors, like a crash or other bug in
litani itself


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
