### PR TITLE
Add dark theme for file-list and pipeline pages

### DIFF
--- a/templates/file-list.jinja.html
+++ b/templates/file-list.jinja.html
@@ -137,6 +137,28 @@ p {
 .graphs img {
   margin-bottom: 6em;
 }
+@media (prefers-color-scheme: dark){
+  body {
+    color: #babdbe;
+    background-color: #263238;
+  }
+  p {
+    color: #babdbe;
+  }
+  #subtitle {
+    color: #fff;
+  }
+  a {
+    color: #29b6f6;
+  }
+  a:hover {
+    color: #ec407a;
+  }
+  #artifact-list {
+    color: white;
+    text-decoration: dotted;
+  }
+}
 </style>
 </head>
 <body>

--- a/templates/pipeline.jinja.html
+++ b/templates/pipeline.jinja.html
@@ -167,6 +167,43 @@ p {
   margin-bottom: 3em;
 }
 
+@media (prefers-color-scheme: dark){
+  body {
+    color: #babdbe;
+    background-color: #263238;
+  }
+  p {
+    color: #babdbe;
+  }
+  #subtitle {
+    color: #fff;
+  }
+  .command-table {
+    background-color: #37474f;
+  }
+  .command-content {
+    background-color: #37474f;
+  }
+  .command-invocation p {
+    color: #fff;
+  }
+  .command-stats-table {
+    background-color: #eae399d0;
+    color: #263238;
+  }
+  .command-stats-table p {
+    color: #263238;
+  }
+  .output-box {
+    color: #cfd8dccc;
+    background-color: #102027;
+  }
+  .stage-name p {
+    text-shadow: -1px  0px 0px #263238,
+                 -2px  0px 0px #26323899,
+                 -1px  1px 0px #26323899;
+  }
+}
 </style>
 </head>
 <body>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add CSS media query and rules for dark mode to file-list and pipeline jinja templates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
