### PR TITLE
Garbage-collect old HTML directories

### DIFF
--- a/lib/capabilities.py
+++ b/lib/capabilities.py
@@ -16,6 +16,7 @@ import json
 
 _CAPABILITIES = {
     "atomic_report_update": "Report directory is rendered atomically",
+    "report_expire": "Old report directories will contain a .litani-expired file",
 }
 
 

--- a/lib/capabilities.py
+++ b/lib/capabilities.py
@@ -17,6 +17,7 @@ import json
 _CAPABILITIES = {
     "atomic_report_update": "Report directory is rendered atomically",
     "report_expire": "Old report directories will contain a .litani-expired file",
+    "dir_lock_api": "lib.litani contains the LockableDirectory API",
 }
 
 

--- a/lib/litani.py
+++ b/lib/litani.py
@@ -31,6 +31,23 @@ VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH = 1, 3, 0
 VERSION = "%d.%d.%d" % (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 
 
+
+class ExpireableDirectory:
+    """This class is to mark directories as being safe for garbage collection"""
+
+    def __init__(self, path: pathlib.Path):
+        self._touchfile = path.resolve() / ".litani-expired"
+
+
+    def expire(self):
+        self._touchfile.touch()
+
+
+    def is_expired(self):
+        return self._touchfile.exists()
+
+
+
 def _get_cache_dir(path=os.getcwd()):
     def cache_pointer_dirs():
         current = pathlib.Path(path).resolve(strict=True)

--- a/lib/litani_report.py
+++ b/lib/litani_report.py
@@ -301,6 +301,8 @@ def get_git_hash():
 
 def render(run, report_dir):
     temporary_report_dir = litani.get_report_data_dir() / str(uuid.uuid4())
+    old_report_dir = litani.ExpireableDirectory(
+        litani.get_report_dir().resolve())
 
     artifact_dir = temporary_report_dir / "artifacts"
     shutil.copytree(litani.get_artifacts_dir(), artifact_dir)
@@ -334,6 +336,7 @@ def render(run, report_dir):
     temp_symlink_dir = report_dir.with_name(report_dir.name + str(uuid.uuid4()))
     os.symlink(temporary_report_dir, temp_symlink_dir)
     os.rename(temp_symlink_dir, report_dir)
+    old_report_dir.expire()
 
 
 def render_artifact_indexes(artifact_dir):

--- a/lib/litani_report.py
+++ b/lib/litani_report.py
@@ -337,6 +337,7 @@ def render(run, report_dir):
     os.symlink(temporary_report_dir, temp_symlink_dir)
     os.rename(temp_symlink_dir, report_dir)
     old_report_dir.expire()
+    litani.unlink_expired()
 
 
 def render_artifact_indexes(artifact_dir):


### PR DESCRIPTION
Litani now marks the previous report directory as 'expired' immediately after writing a new one and moving the `html` symbolic link from the old to the new directory. Litani then deletes all expired report directories.

Since there is a risk that external processes might still be reading old report directories after having dereferenced the old `html` symlink, Litani now exposes an API for locking directories in a POSIX-compliant manner. External processes are expected to take a lock on report directories before attempting to access them. Litani will not delete expired directories as long as they are locked by external processes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
