### PR TITLE
Fix Atomic Lock API behavior

### DIFF
--- a/lib/capabilities.py
+++ b/lib/capabilities.py
@@ -17,7 +17,8 @@ import json
 _CAPABILITIES = {
     "atomic_report_update": "Report directory is rendered atomically",
     "report_expire": "Old report directories will contain a .litani-expired file",
-    "dir_lock_api": "lib.litani contains the LockableDirectory API",
+    "dir_lock_api": "Deprecated",
+    "dir_lock_api_v2": "lib.litani contains the LockableDirectory API",
 }
 
 

--- a/lib/litani.py
+++ b/lib/litani.py
@@ -65,11 +65,10 @@ class LockableDirectory:
 
 
     def __init__(self, path: pathlib.Path):
-        """Directory is initially released"""
+        """Directory is initially locked"""
 
         self.path = path.resolve()
         self._lock_file = self.path / ".litani-lock"
-        self.release()
 
 
     # Non-blocking =============================================================

--- a/lib/litani.py
+++ b/lib/litani.py
@@ -252,6 +252,7 @@ def unlink_expired():
             continue
         expire_dir = ExpireableDirectory(data_dir)
         if expire_dir.is_expired():
+            logging.debug("Unlinking %s", str(data_dir))
             shutil.rmtree(data_dir)
             # No need to release lock after deletion
         else:

--- a/lib/litani_report.py
+++ b/lib/litani_report.py
@@ -339,6 +339,7 @@ def render(run, report_dir):
 
     # Release lock so that other processes can read from this directory
     new_report_dir = litani.LockableDirectory(report_dir.resolve())
+    new_report_dir.release()
 
     old_report_dir.expire()
     litani.unlink_expired()

--- a/lib/litani_report.py
+++ b/lib/litani_report.py
@@ -301,8 +301,9 @@ def get_git_hash():
 
 def render(run, report_dir):
     temporary_report_dir = litani.get_report_data_dir() / str(uuid.uuid4())
-    old_report_dir = litani.ExpireableDirectory(
-        litani.get_report_dir().resolve())
+    temporary_report_dir.mkdir(parents=True)
+    old_report_dir_path = litani.get_report_dir().resolve()
+    old_report_dir = litani.ExpireableDirectory(old_report_dir_path)
 
     artifact_dir = temporary_report_dir / "artifacts"
     shutil.copytree(litani.get_artifacts_dir(), artifact_dir)
@@ -341,7 +342,8 @@ def render(run, report_dir):
     new_report_dir = litani.LockableDirectory(report_dir.resolve())
     new_report_dir.release()
 
-    old_report_dir.expire()
+    if old_report_dir_path.exists():
+        old_report_dir.expire()
     litani.unlink_expired()
 
 

--- a/litani
+++ b/litani
@@ -27,6 +27,7 @@ import sys
 import tempfile
 import threading
 import time
+import traceback
 import uuid
 
 from lib import litani, litani_report, ninja_syntax
@@ -385,19 +386,23 @@ def validate_run(run):
 
 
 def continuous_render_report(cache_dir, report_dir, killer, out_file):
-    while True:
-        run = litani_report.get_run_data(cache_dir)
-        validate_run(run)
-        with litani.atomic_write(cache_dir / litani.RUN_FILE) as handle:
-            print(json.dumps(run, indent=2), file=handle)
-        if out_file is not None:
-            with litani.atomic_write(out_file) as handle:
+    try:
+        while True:
+            run = litani_report.get_run_data(cache_dir)
+            validate_run(run)
+            with litani.atomic_write(cache_dir / litani.RUN_FILE) as handle:
                 print(json.dumps(run, indent=2), file=handle)
-        litani_report.render(run, report_dir)
-        if killer.is_set():
-            break
-        time.sleep(2)
-
+            if out_file is not None:
+                with litani.atomic_write(out_file) as handle:
+                    print(json.dumps(run, indent=2), file=handle)
+            litani_report.render(run, report_dir)
+            if killer.is_set():
+                break
+            time.sleep(2)
+    except Exception as e:
+        logging.error("Continuous render function crashed")
+        logging.error(str(e))
+        traceback.print_exc()
 
 def set_up_logging(args):
     if args.very_verbose:

--- a/unit/lockable_directory.py
+++ b/unit/lockable_directory.py
@@ -31,13 +31,14 @@ class TestLockableDirectory(unittest.TestCase):
         self.temp_dir.cleanup()
 
 
-    def test_can_initially_acquire(self):
+    def test_cannot_initially_acquire(self):
         lock_dir = lib.litani.LockableDirectory(self.temp_dir_p)
-        self.assertTrue(lock_dir.acquire())
+        self.assertFalse(lock_dir.acquire())
 
 
     def test_can_acquire_after_release(self):
         lock_dir = lib.litani.LockableDirectory(self.temp_dir_p)
+        lock_dir.release()
         self.assertTrue(lock_dir.acquire())
         lock_dir.release()
         self.assertTrue(lock_dir.acquire())
@@ -45,12 +46,14 @@ class TestLockableDirectory(unittest.TestCase):
 
     def test_no_double_acquire(self):
         lock_dir = lib.litani.LockableDirectory(self.temp_dir_p)
+        lock_dir.release()
         self.assertTrue(lock_dir.acquire())
         self.assertFalse(lock_dir.acquire())
 
 
     def test_repeat_no_double_acquire(self):
         lock_dir = lib.litani.LockableDirectory(self.temp_dir_p)
+        lock_dir.release()
         self.assertTrue(lock_dir.acquire())
         self.assertFalse(lock_dir.acquire())
 
@@ -62,12 +65,14 @@ class TestLockableDirectory(unittest.TestCase):
 
     def test_try_acquire(self):
         lock_dir = lib.litani.LockableDirectory(self.temp_dir_p)
+        lock_dir.release()
         with lock_dir.try_acquire():
             pass # No exception
 
 
     def test_no_double_try_acquire(self):
         lock_dir = lib.litani.LockableDirectory(self.temp_dir_p)
+        lock_dir.release()
         with lock_dir.try_acquire():
             with self.assertRaises(lib.litani.AcquisitionFailed):
                 with lock_dir.try_acquire():
@@ -76,13 +81,13 @@ class TestLockableDirectory(unittest.TestCase):
 
     def test_no_try_acquire_acquire(self):
         lock_dir = lib.litani.LockableDirectory(self.temp_dir_p)
+        lock_dir.release()
         with lock_dir.try_acquire():
             self.assertFalse(lock_dir.acquire())
 
 
     def test_no_acquire_try_acquire(self):
         lock_dir = lib.litani.LockableDirectory(self.temp_dir_p)
-        lock_dir.acquire()
         with self.assertRaises(lib.litani.AcquisitionFailed):
             with lock_dir.try_acquire():
                 pass
@@ -90,6 +95,7 @@ class TestLockableDirectory(unittest.TestCase):
 
     def test_context_manager_releases(self):
         lock_dir = lib.litani.LockableDirectory(self.temp_dir_p)
+        lock_dir.release()
         with lock_dir.try_acquire():
             pass
         self.assertTrue(lock_dir.acquire())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make it so that the LockableDirectory class is initially locked and has to call `release()`, just in case two processes are trying to Lock a Directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
