### PR TITLE
Add outcome table support

### DIFF
--- a/lib/capabilities.py
+++ b/lib/capabilities.py
@@ -19,6 +19,7 @@ _CAPABILITIES = {
     "report_expire": "Old report directories will contain a .litani-expired file",
     "dir_lock_api": "Deprecated",
     "dir_lock_api_v2": "lib.litani contains the LockableDirectory API",
+    "outcome_table": "The --outcome-table flag is supported",
 }
 
 

--- a/lib/job_outcome.py
+++ b/lib/job_outcome.py
@@ -1,0 +1,233 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+import dataclasses
+import json
+import logging
+import os
+import subprocess
+
+
+################################################################################
+# Decider classes
+# ``````````````````````````````````````````````````````````````````````````````
+# Each of these classes has get_job_fields method.  The class evaluates what
+# the result of a single Litani job is and returns that result in the dict.
+################################################################################
+
+
+
+@dataclasses.dataclass
+class OutcomeTableDecider:
+    """Decide what the result of a job is based on an outcome table.
+
+    An 'outcome table' is a mapping from 'outcomes'---like return codes,
+    timeouts, or a wildcard---to whether or not the job is successful. This
+    class takes a user-specified or default outcome table, and decides what the
+    result of a single Litani job was by iterating through the table.
+    """
+
+    table: dict
+    proc: subprocess.CompletedProcess
+    timeout_reached: bool
+    loaded_from_file: bool
+
+
+    def _get_wildcard_outcome(self):
+        for outcome in self.table["outcomes"]:
+            if outcome["type"] == "wildcard":
+                return outcome["action"]
+        raise UserWarning(
+            "Outcome table contains no wildcard rule: %s" % json.dumps(
+                self.table, indent=2))
+
+
+    def _get_timeout_outcome(self):
+        for outcome in self.table["outcomes"]:
+            if outcome["type"] == "timeout":
+                return outcome["action"]
+        return None
+
+
+    def _get_return_code_outcome(self, return_code):
+        for outcome in self.table["outcomes"]:
+            if outcome["type"] == "return-code" and \
+                    outcome["value"] == return_code:
+                return outcome["action"]
+        return None
+
+
+    def get_job_fields(self):
+        return {
+            "outcome": self.get_outcome(),
+            "loaded_outcome_dict":
+                self.table if self.loaded_from_file else None
+        }
+
+
+    def get_outcome(self):
+        timeout_outcome = self._get_timeout_outcome()
+        if self.timeout_reached:
+            if timeout_outcome:
+                return timeout_outcome
+            return self._get_wildcard_outcome()
+
+        rc_outcome = self._get_return_code_outcome(self.proc.returncode)
+        if rc_outcome:
+            return rc_outcome
+
+        return self._get_wildcard_outcome()
+
+
+
+################################################################################
+# Utilities
+################################################################################
+
+
+def _get_default_outcome_dict(args):
+    """Litani's default behavior if the user does not specify an outcome table.
+
+    This is not a constant dict as it also depends on whether the user passed in
+    command-line flags that affect how the result is decided, like
+    --ignore-returns etc.
+    """
+
+    outcomes = []
+    if args.timeout_ok:
+        outcomes.append({
+            "type": "timeout",
+            "action": "success",
+        })
+    elif args.timeout_ignore:
+        outcomes.append({
+            "type": "timeout",
+            "action": "fail_ignored",
+        })
+
+    if args.ok_returns:
+        for rc in args.ok_returns:
+            outcomes.append({
+                "type": "return-code",
+                "value": int(rc),
+                "action": "success",
+            })
+
+    if args.ignore_returns:
+        for rc in args.ignore_returns:
+            outcomes.append({
+                "type": "return-code",
+                "value": int(rc),
+                "action": "fail_ignored",
+            })
+
+    outcomes.extend([{
+        "type": "return-code",
+        "value": 0,
+        "action": "success",
+    }, {
+        "type": "wildcard",
+        "action": "fail",
+    }])
+
+    return {"outcomes": outcomes}
+
+
+def validate_outcome_table(table):
+    try:
+        import voluptuous
+    except ImportError:
+        logging.debug("Skipping outcome table validation as voluptuous is not installed")
+        return
+
+    actions = voluptuous.Any("success", "fail", "fail_ignored")
+    schema = voluptuous.Schema({
+        # A description of the outcome table as a whole.
+        voluptuous.Optional("comment"): str,
+
+        # We use the first item in this list that matches the job
+        "outcomes": [voluptuous.Any({
+            "type": "return-code",
+            "value": int,
+            "action": actions,
+            voluptuous.Optional("comment"): str,
+        }, {
+            "type": "timeout",
+            "action": actions,
+            voluptuous.Optional("comment"): str,
+        }, {
+            "type": "wildcard",
+            "action": actions,
+            voluptuous.Optional("comment"): str,
+        })]
+    }, required=True)
+    voluptuous.humanize.validate_with_humanized_errors(table, schema)
+
+
+def _get_outcome_table_job_decider(args, proc, timeout_reached):
+    if args.outcome_table:
+        _, ext = os.path.splitext(args.outcome_table)
+        with open(args.outcome_table) as handle:
+            if ext == ".json":
+                outcome_table = json.load(handle)
+            elif ext == ".yaml":
+                import yaml
+                outcome_table = yaml.safe_load(handle)
+            else:
+                raise UserWarning("Unsupported outcome table format (%s)" % ext)
+        loaded_from_file = True
+    else:
+        loaded_from_file = False
+        outcome_table = _get_default_outcome_dict(args)
+
+    logging.debug("Using outcome table: %s", json.dumps(outcome_table, indent=2))
+    validate_outcome_table(outcome_table)
+
+    return OutcomeTableDecider(
+        outcome_table, proc, timeout_reached, loaded_from_file=loaded_from_file)
+
+
+################################################################################
+# Entry point
+################################################################################
+
+
+def fill_in_result(proc, timeout_reached, job_data, args):
+    """Add fields pertaining to job result to job_data dict
+
+    The 'result' of a job can be evaluated in several ways. The most simple
+    mechanism, where a return code of 0 means success and anything else is a
+    failure, is encoded by the "default outcome table". Users can also supply
+    their own outcome table as a JSON file, and other mechanisms could be
+    available in the future.
+
+    Depending on how we are to evaluate the result, we construct an instance of
+    one of the Decider classes in this module, and use the Decider to evaluate
+    the result of the job. The result is a dict, whose keys and values we add to
+    the job's dict.
+    """
+
+    job_data["complete"] = True
+    job_data["timeout_reached"] = timeout_reached
+    job_data["command_return_code"] = proc.returncode
+
+    # These get set by the deciders
+    job_data["loaded_outcome_dict"] = None
+
+    decider = _get_outcome_table_job_decider(args, proc, timeout_reached)
+
+    fields = decider.get_job_fields()
+    for k, v in fields.items():
+        job_data[k] = v
+    job_data["wrapper_return_code"] = 1 if job_data["outcome"] == "fail" else 0

--- a/lib/litani_report.py
+++ b/lib/litani_report.py
@@ -132,7 +132,7 @@ def add_stage_stats(stage, stage_name, pipeline_name):
                 json.dumps(stage, indent=2))
             sys.exit(1)
     stage["status"] = status.name.lower()
-    stage["url"] = "artifacts/%s/%s/index.html" % (pipeline_name, stage_name)
+    stage["url"] = "artifacts/%s/%s" % (pipeline_name, stage_name)
     stage["name"] = stage_name
 
 
@@ -143,7 +143,7 @@ class PipeStatus(enum.IntEnum):
 
 
 def add_pipe_stats(pipe):
-    pipe["url"] = "pipelines/%s/index.html" % pipe["name"]
+    pipe["url"] = "pipelines/%s" % pipe["name"]
     incomplete = [s for s in pipe["ci_stages"] if not s["complete"]]
     if incomplete:
         pipe["status"] = PipeStatus.IN_PROGRESS

--- a/lib/litani_report.py
+++ b/lib/litani_report.py
@@ -109,7 +109,7 @@ class StageStatus(enum.IntEnum):
 
 def add_stage_stats(stage, stage_name, pipeline_name):
     n_complete_jobs = len([j for j in stage["jobs"] if j["complete"]])
-    if len(stage["jobs"]):
+    if stage["jobs"]:
         stage["progress"] = int(n_complete_jobs * 100 / len(stage["jobs"]))
         stage["complete"] = n_complete_jobs == len(stage["jobs"])
     else:

--- a/litani
+++ b/litani
@@ -33,6 +33,7 @@ import uuid
 from lib import litani, litani_report, ninja_syntax
 import lib.capabilities
 import lib.graph
+import lib.job_outcome
 
 
 VALIDATE_DATA = False
@@ -103,6 +104,11 @@ def get_add_job_args():
             "nargs": "+",
             "help": "if the job exits with one of the listed return codes, "
                     "continue the build but fail at the end"
+        }, {
+            "flags": ["--outcome-table"],
+            "metavar": "F",
+            "help": "path to a JSON outcome table that determines the outcome "
+                    "of this job"
         }, {
             "flags": ["--interleave-stdout-stderr"],
             "action": "store_true",
@@ -313,6 +319,7 @@ def get_single_job_arguments():
         "stderr_file": voluptuous.Any(str, None),
         "stdout_file": voluptuous.Any(str, None),
         "ok_returns": voluptuous.Any([str], None),
+        "outcome_table": voluptuous.Any(str, None),
         "ignore_returns": voluptuous.Any([str], None),
         "subcommand": voluptuous.Any("exec", "add-job"),
     }
@@ -331,6 +338,7 @@ def validate_run(run):
     if not VALIDATE_DATA:
         return
     import voluptuous
+    outcome = voluptuous.Any("success", "fail", "fail_ignored")
     schema = voluptuous.Schema({
         "run_id": str,
         "project": str,
@@ -363,6 +371,7 @@ def validate_run(run):
                 }, {
                     "duration": int,
                     "complete": True,
+                    "outcome": outcome,
                     "end_time": time_str,
                     "start_time": time_str,
                     "timeout_reached": bool,
@@ -371,6 +380,7 @@ def validate_run(run):
                     "stderr": voluptuous.Any([str], None),
                     "stdout": voluptuous.Any([str], None),
                     "duration_str": voluptuous.Any(str, None),
+                    "loaded_outcome_dict": voluptuous.Any(dict, None),
                 })]
             }]
         }]
@@ -446,7 +456,7 @@ def make_litani_exec_command(add_args):
     for arg in [
             "command", "pipeline_name", "ci_stage", "cwd", "job_id",
             "stdout_file", "stderr_file", "description", "timeout",
-            "status_file",
+            "status_file", "outcome_table",
     ]:
         if arg in add_args and add_args[arg]:
             cmd.append("--%s" % arg.replace("_", "-"))
@@ -641,7 +651,7 @@ def run_build(args):
                 continue
             with open(os.path.join(root, fyle)) as handle:
                 job_status = json.load(handle)
-            if job_status["command_return_code"]:
+            if job_status["outcome"] != "success":
                 success = False
     run_info["status"] = "success" if success else "failure"
 
@@ -686,26 +696,15 @@ def exec_job(args):
         args=args.command, shell=True, universal_newlines=True,
         stdout=subprocess.PIPE, stderr=stderr, cwd=args.cwd)
 
-    out_data["wrapper_return_code"] = 0
-
+    timeout_reached = False
     try:
         proc_out, proc_err = proc.communicate(timeout=args.timeout)
     except subprocess.TimeoutExpired:
         proc.kill()
         proc_out, proc_err = proc.communicate()
-        out_data["timeout_reached"] = True
-        if not args.timeout_ignore:
-            out_data["wrapper_return_code"] = 1
-    else:
-        out_data["timeout_reached"] = False
+        timeout_reached = True
 
-    out_data["command_return_code"] = proc.returncode
-    out_data["complete"] = True
-    ignore_returns = args.ignore_returns if args.ignore_returns else []
-    ignore_returns = [int(i) for i in ignore_returns]
-    ignore_returns.append(0)
-    if proc.returncode not in ignore_returns:
-        out_data["wrapper_return_code"] = 1
+    lib.job_outcome.fill_in_result(proc, timeout_reached, out_data, args)
 
     for out_field, proc_pipe, arg_file in [
         ("stdout", proc_out, args.stdout_file),
@@ -747,10 +746,6 @@ def exec_job(args):
             except FileExistsError:
                 logging.warning(
                     "Multiple files with same name in artifacts directory")
-                pass
-
-    if out_data["wrapper_return_code"] == 0:
-        sys.exit(0)
 
     sys.exit(out_data["wrapper_return_code"])
 

--- a/litani
+++ b/litani
@@ -332,13 +332,13 @@ def validate_run(run):
         return
     import voluptuous
     schema = voluptuous.Schema({
+        "run_id": str,
+        "project": str,
+        "start_time": time_str,
         "version": litani.VERSION,
         "version_major": litani.VERSION_MAJOR,
         "version_minor": litani.VERSION_MINOR,
         "version_patch": litani.VERSION_PATCH,
-        "run_id": str,
-        "project": str,
-        "start_time": time_str,
         voluptuous.Optional("end_time"): time_str,
         "status": voluptuous.Any("in_progress", "fail", "success"),
         "pipelines": [{
@@ -353,13 +353,13 @@ def validate_run(run):
                 "progress": voluptuous.All(int, voluptuous.Range(min=0, max=100)),
                 "jobs": [voluptuous.Any({
                     "complete": False,
-                    "wrapper_arguments": get_single_job_arguments(),
                     "duration_str": voluptuous.Any(str, None),
+                    "wrapper_arguments": get_single_job_arguments(),
                 }, {
                     "complete": False,
                     "start_time": time_str,
-                    "wrapper_arguments": get_single_job_arguments(),
                     "duration_str": voluptuous.Any(str, None),
+                    "wrapper_arguments": get_single_job_arguments(),
                 }, {
                     "duration": int,
                     "complete": True,
@@ -370,7 +370,6 @@ def validate_run(run):
                     "wrapper_return_code": int,
                     "stderr": voluptuous.Any([str], None),
                     "stdout": voluptuous.Any([str], None),
-                    "wrapper_arguments": get_single_job_arguments(),
                     "duration_str": voluptuous.Any(str, None),
                 })]
             }]

--- a/templates/dashboard.jinja.html
+++ b/templates/dashboard.jinja.html
@@ -319,7 +319,7 @@ p {
 
       <div class="pipeline-link">
             <svg height="16px" width="32px" class="pipeline-icon">
-              <a href="{{ pipe['url'] }}">
+              <a href="{{ pipe['url'] }}/index.html">
                 <polygon points="0,0 0,16 16,32 32,0"
                          style="fill:#ffffff01"></polygon>
                 <polygon points="
@@ -340,7 +340,7 @@ p {
         <div class="pipeline-stage">
 
           <a class="stage-artifacts-link {{ stage['status'] }}"
-             href="{{ stage['url'] }}">
+             href="{{ stage['url'] }}/index.html">
             <div class="stage-bar">
               <div class="progress" style="width: {{ stage['progress'] }}%">
               </div><!-- class="progress" -->

--- a/templates/outcome_table.jinja.html
+++ b/templates/outcome_table.jinja.html
@@ -1,0 +1,223 @@
+{#-
+ # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License").
+ # You may not use this file except in compliance with the License.
+ # A copy of the License is located at
+ #
+ #     http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # or in the "license" file accompanying this file. This file is
+ # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ # ANY KIND, either express or implied. See the License for the specific
+ # language governing permissions and limitations under the License.
+-#}
+ <!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>
+    Outcome table
+  </title>
+<style>
+#title{
+  background-color: #ec407a;
+  color: white;
+  padding: 2em;
+}
+h1 {
+  margin-bottom: 0em;
+}
+#subtitle {
+  font-variant: small-caps;
+  text-transform: lowercase;
+  letter-spacing: 0.2em;
+}
+#content {
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-top: 2em;
+  padding-bottom: 2em;
+  color: #263238;
+  font-family: Helvetica, sans-serif;
+}
+p {
+  margin: 0;
+}
+#outcome-table {
+  margin-top: 4em;
+  display: grid;
+  grid-template-columns: 6em 4em auto;
+  align-items: center;
+}
+
+.comment {
+  padding: 0.5em;
+}
+
+.action {
+  height: 3em;
+  width: 3em;
+  border-radius: 5px;
+  border: 1px solid #4b636e;
+  margin: 0.5em;
+}
+
+.fail_ignored {
+  background-color: #ff9800;
+}
+
+.fail {
+  background-color: #f44336;
+}
+
+.success {
+  background-color: #3f51b5;
+}
+
+.outcome {
+  justify-self: center;
+}
+.small-large,  .half-split{
+  justify-self: center;
+  display: flow;
+  flex-direction: column;
+  text-align: center;
+}
+.small-large .top {
+  text-transform: lowercase;
+  font-variant: small-caps;
+  font-size: small;
+  margin-bottom: 0.2em;
+  margin-top: 0.5em;
+}
+.small-large .bottom {
+  font-size: xx-large;
+}
+.half-split .top {
+  text-transform: lowercase;
+  font-variant: small-caps;
+  margin-bottom: 0.2em;
+  margin-top: 0.5em;
+}
+.half-split .bottom {
+  text-transform: lowercase;
+  font-variant: small-caps;
+}
+
+@media (max-width: 640px){
+  .pipeline-progress {
+    width: 10em;
+  }
+  #build-title:after  { content: 'B'; visibility: visible; margin-left: -1.5em}
+  #test-title:after   { content: 'T'; visibility: visible; margin-left: -2.5em}
+  #report-title:after { content: 'R'; visibility: visible; margin-left: -3.5em}
+  #build-title        { visibility: hidden; }
+  #test-title         { visibility: hidden; }
+  #report-title       { visibility: hidden; }
+}
+@media (prefers-color-scheme: dark){
+  .status-icon-in-progress { fill: #ddd; }
+  .status-icon-in-progress circle { stroke: #ddd; }
+
+  .pipeline-header {
+    color: #eceff1;
+  }
+  .pipeline-row {
+    color: #eceff1;
+    background-color: #37474f;
+  }
+  body {
+    color: #babdbe;
+    background-color: #263238;
+  }
+  p {
+    color: #babdbe;
+  }
+  #subtitle {
+    color: #fff;
+  }
+  .action {
+    border: 1px solid #cfd8dc;
+  }
+  #table-comment {
+    margin-top: 4em;
+  }
+
+}
+</style>
+</head>
+<body>
+<div id="content">
+
+  <div id="title">
+    <h1>
+      Outcome Table
+    </h1>
+    <p id="subtitle">
+      Litani CI Dashboard
+    </p>
+  </div><!-- id="title" -->
+
+  {% if "comment" in table %}
+  <p id="table-comment">
+  {{ table["comment"] }}
+  </p><!-- id="table-comment"-->
+  {% endif %}{# "comment" in table #}
+
+  <div id="outcome-table">
+
+    {% for outcome in table["outcomes"] %}
+    <div class="outcome">
+
+      {% if outcome["type"] == "return-code" %}
+      <div class="small-large">
+        <div class="top">
+          <p>return code</p>
+        </div>
+        <div class="bottom">
+          <p>{{ outcome["value"] }}</p>
+        </div>
+      </div>
+
+      {% elif outcome["type"] == "timeout" %}
+      <div class="half-split">
+        <div class="top">
+          <p>time</p>
+        </div>
+        <div class="bottom">
+          <p>out</p>
+        </div>
+      </div>
+
+      {% elif outcome["type"] == "wildcard" %}
+      <div class="half-split">
+        <div class="top">
+          <p>everything</p>
+        </div>
+        <div class="bottom">
+          <p>else</p>
+        </div>
+      </div>
+      {% endif %}{# outcome["type"] == "return-code" #}
+    </div><!-- class="outcome" -->
+
+    <div class="action {{ outcome["action"] }}">
+    </div>
+
+    <div class="comment">
+      {% if "comment" in outcome %}
+      <p>{{ outcome["comment"] }}</p>
+      {% endif %}{# "comment" in outcome #}
+    </div>
+
+    {% endfor %}{# outcome in table["outcomes"] #}
+
+  </div><!-- id="outcome-table" -->
+
+
+</div><!-- id="content" -->
+</body>
+</html>

--- a/templates/pipeline.jinja.html
+++ b/templates/pipeline.jinja.html
@@ -167,10 +167,26 @@ p {
   margin-bottom: 3em;
 }
 
+.outcome-table-info-box {
+  margin-top: 0.4em;
+  margin-bottom: 0.2em;
+  padding: 1em;
+  color: #000a12;
+  background-color: #ffee58;
+  border-radius: 0.5em;
+}
+.outcome-table-info-box .outcome{
+  font-weight: bold;
+}
+
+
 @media (prefers-color-scheme: dark){
   body {
     color: #babdbe;
     background-color: #263238;
+  }
+  .outcome-table-info-box p{
+    color: #000a12;
   }
   p {
     color: #babdbe;
@@ -237,7 +253,7 @@ p {
     <div class="command-table">
       {% if not job["complete"] %}
       <div class="in-progress">
-      {% elif not job["command_return_code"] %}
+      {% elif job["outcome"] == "success" %}
       <div class="success">
       {% else %}
       <div class="fail">
@@ -307,15 +323,29 @@ p {
             <div class="command-stats-row">
               <p>Command successful:
               <span class="value">
-              {% if job["command_return_code"] %}
-              no
-              {% else %}
+              {% if job["outcome"] == "success" %}
               yes
-              {% endif %}{# job["command_return_code"] #}
+              {% else %}
+              no
+              {% endif %}{# job["outcome"] == "success"#}
               </span></p>
             </div><!-- class="command-stats-row" -->
           </div><!-- class="command-stats-table" -->
           {% endif %}{# job["complete"] #}
+
+          {% if job["complete"] and job["loaded_outcome_dict"] %}
+          <div class="outcome-table-info-box">
+            <p>
+              An outcome table decided the outcome
+              &lsquo;<span class="outcome">{{ job["outcome"] }}</span>&rsquo;
+              for this job. View the table
+              <a href="{{ job['outcome_table_html_url'] }}">here</a>
+              (or view the
+              <a href="{{ job['outcome_table_json_url'] }}">raw JSON</a>).
+            </p>
+          </div><!-- class="outcome-table-info-box" -->
+          {% endif %}{# job["loaded_outcome_dict"] #}
+
 
           {% if job["stdout"] %}
           <div class="output-box"><xmp>stdout:

--- a/unit/outcome_table_decider.py
+++ b/unit/outcome_table_decider.py
@@ -1,0 +1,249 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+import unittest
+import unittest.mock
+
+import lib.job_outcome
+
+
+class CBMCNegativeTest(unittest.TestCase):
+    def setUp(self):
+        self.table = {
+            "comment": "",
+            "outcomes": [{
+                "type": "return-code",
+                "value": 0,
+                "action": "fail_ignored",
+            }, {
+                "type": "return-code",
+                "value": 10,
+                "action": "success",
+            }, {
+                "type": "wildcard",
+                "action": "fail",
+            }]
+        }
+
+
+    def assert_outcome_equals(self, jod, outcome):
+        self.assertEqual(jod.get_job_fields(), outcome)
+
+
+    def test_zero(self):
+        proc = unittest.mock.Mock()
+        proc.returncode = 0
+        jod = lib.job_outcome.OutcomeTableDecider(self.table, proc, False, True)
+
+        self.assert_outcome_equals(jod, {
+                "outcome": "fail_ignored",
+                "loaded_outcome_dict": self.table,
+            })
+
+
+    def test_success(self):
+        proc = unittest.mock.Mock()
+        proc.returncode = 10
+        jod = lib.job_outcome.OutcomeTableDecider(self.table, proc, False, True)
+
+        self.assert_outcome_equals(jod, {
+                "outcome": "success",
+                "loaded_outcome_dict": self.table,
+            })
+
+
+
+class CBMCTest(unittest.TestCase):
+    def setUp(self):
+        self.table = {
+            "comment": "",
+            "outcomes": [{
+                "type": "return-code",
+                "value": 0,
+                "action": "success",
+            }, {
+                "type": "return-code",
+                "value": 10,
+                "action": "fail_ignored",
+            }, {
+                "type": "wildcard",
+                "action": "fail",
+            }]
+        }
+
+
+    def assert_outcome_equals(self, jod, outcome):
+        self.assertEqual(jod.get_job_fields(), outcome)
+
+
+    def test_success(self):
+        proc = unittest.mock.Mock()
+        proc.returncode = 0
+        jod = lib.job_outcome.OutcomeTableDecider(self.table, proc, False, True)
+
+        self.assert_outcome_equals(jod, {
+                "outcome": "success",
+                "loaded_outcome_dict": self.table,
+            })
+
+
+    def test_ten(self):
+        proc = unittest.mock.Mock()
+        proc.returncode = 10
+        jod = lib.job_outcome.OutcomeTableDecider(self.table, proc, False, True)
+
+        self.assert_outcome_equals(jod, {
+                "outcome": "fail_ignored",
+                "loaded_outcome_dict": self.table,
+            })
+
+
+    def test_one(self):
+        proc = unittest.mock.Mock()
+        proc.returncode = 1
+        jod = lib.job_outcome.OutcomeTableDecider(self.table, proc, False, True)
+
+        self.assert_outcome_equals(jod, {
+                "outcome": "fail",
+                "loaded_outcome_dict": self.table,
+            })
+
+
+    def test_timeout_one(self):
+        proc = unittest.mock.Mock()
+        proc.returncode = 1
+        jod = lib.job_outcome.OutcomeTableDecider(self.table, proc, True, True)
+
+        self.assert_outcome_equals(jod, {
+                "outcome": "fail",
+                "loaded_outcome_dict": self.table,
+            })
+
+
+    def test_timeout_ten(self):
+        proc = unittest.mock.Mock()
+        proc.returncode = 10
+        jod = lib.job_outcome.OutcomeTableDecider(self.table, proc, True, True)
+
+        self.assert_outcome_equals(jod, {
+                "outcome": "fail",
+                "loaded_outcome_dict": self.table,
+            })
+
+
+    def test_timeout_zero(self):
+        # This is sort of weird, in that we wouldn't expect a process to return
+        # 0 if it's been killed by timeout_happened. Nevertheless, failing is the right
+        # thing to do in that case.
+        proc = unittest.mock.Mock()
+        proc.returncode = 0
+        jod = lib.job_outcome.OutcomeTableDecider(self.table, proc, True, True)
+
+        self.assert_outcome_equals(jod, {
+                "outcome": "fail",
+                "loaded_outcome_dict": self.table,
+            })
+
+
+
+class TimeoutPriorityTest(unittest.TestCase):
+    def setUp(self):
+        self.table = {
+            "comment": "",
+            "outcomes": [{
+                "type": "return-code",
+                "value": 0,
+                "action": "success",
+            }, {
+                "type": "return-code",
+                "value": 10,
+                "action": "fail_ignored",
+            }, {
+                "type": "timeout",
+                "action": "fail_ignored",
+            }, {
+                "type": "wildcard",
+                "action": "fail",
+            }]
+        }
+
+
+    def assert_outcome_equals(self, jod, outcome):
+        self.assertEqual(jod.get_job_fields(), outcome)
+
+
+    def test_success(self):
+        proc = unittest.mock.Mock()
+        proc.returncode = 0
+        jod = lib.job_outcome.OutcomeTableDecider(self.table, proc, False, True)
+
+        self.assert_outcome_equals(jod, {
+                "outcome": "success",
+                "loaded_outcome_dict": self.table,
+            })
+
+
+    def test_ten(self):
+        proc = unittest.mock.Mock()
+        proc.returncode = 10
+        jod = lib.job_outcome.OutcomeTableDecider(self.table, proc, False, True)
+
+        self.assert_outcome_equals(jod, {
+                "outcome": "fail_ignored",
+                "loaded_outcome_dict": self.table,
+            })
+
+
+    def test_one(self):
+        proc = unittest.mock.Mock()
+        proc.returncode = 1
+        jod = lib.job_outcome.OutcomeTableDecider(self.table, proc, False, True)
+
+        self.assert_outcome_equals(jod, {
+                "outcome": "fail",
+                "loaded_outcome_dict": self.table,
+            })
+
+
+    def test_timeout_one(self):
+        proc = unittest.mock.Mock()
+        proc.returncode = 1
+        jod = lib.job_outcome.OutcomeTableDecider(self.table, proc, True, True)
+
+        self.assert_outcome_equals(jod, {
+                "outcome": "fail_ignored",
+                "loaded_outcome_dict": self.table,
+            })
+
+
+    def test_timeout_ten(self):
+        proc = unittest.mock.Mock()
+        proc.returncode = 10
+        jod = lib.job_outcome.OutcomeTableDecider(self.table, proc, True, True)
+
+        self.assert_outcome_equals(jod, {
+                "outcome": "fail_ignored",
+                "loaded_outcome_dict": self.table,
+            })
+
+
+    def test_timeout_zero(self):
+        proc = unittest.mock.Mock()
+        proc.returncode = 0
+        jod = lib.job_outcome.OutcomeTableDecider(self.table, proc, True, True)
+
+        self.assert_outcome_equals(jod, {
+                "outcome": "fail_ignored",
+                "loaded_outcome_dict": self.table,
+            })


### PR DESCRIPTION
This commit adds the --outcome-table flag to the `litani add-job`
command. This flag allows users to pass in an "outcome table" as a JSON
file, which litani uses to decide whether a job succeeded or failed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
