### PR TITLE
Support adding jobs to a job pool

### DIFF
--- a/lib/capabilities.py
+++ b/lib/capabilities.py
@@ -22,6 +22,7 @@ _CAPABILITIES = {
     "outcome_table": "The --outcome-table flag is supported",
     "output_directory_flags": "The --output-directory --output-symlink and "
         "--output-prefix flags are supported",
+    "pools": "Jobs can be added to task pools to limit parallelism",
 }
 
 

--- a/lib/validation.py
+++ b/lib/validation.py
@@ -39,6 +39,7 @@ def _get_single_job_arguments():
         "timeout_ignore": bool,
         "cwd": voluptuous.Any(str, None),
         "interleave_stdout_stderr": bool,
+        "pool": voluptuous.Any(str, None),
         "tags": voluptuous.Any([str], None),
         "timeout": voluptuous.Any(int, None),
         "inputs": voluptuous.Any([str], None),
@@ -69,6 +70,7 @@ def validate_run(run):
     schema = voluptuous.Schema({
         "run_id": str,
         "project": str,
+        "pools": {str: int},
         "start_time": _time_str,
         "version": lib.litani.VERSION,
         "version_major": lib.litani.VERSION_MAJOR,

--- a/litani
+++ b/litani
@@ -122,6 +122,10 @@ def get_add_job_args():
             "flags": ["--stderr-file"],
             "metavar": "FILE",
             "help": "file to redirect stderr to"
+        }, {
+            "flags": ["--pool"],
+            "metavar": "NAME",
+            "help": "pool to which this job should be added"
         }]), (
         "misc", [{
             "flags": ["--description"],
@@ -185,6 +189,12 @@ def get_args():
             "required": True,
             "help": "Project that this proof run is associated with",
             "metavar": "NAME",
+        }, {
+            "flags": ["--pools"],
+            "help":
+                "Job pools to which jobs can be added, with depth of each pool",
+            "metavar": "NAME:DEPTH",
+            "nargs": "+",
         }, {
             "flags": ["--output-symlink"],
             "help": "Create a symbolic link from DIR to litani's output directory",
@@ -366,7 +376,7 @@ def make_litani_exec_command(add_args):
     for arg in [
             "command", "pipeline_name", "ci_stage", "cwd", "job_id",
             "stdout_file", "stderr_file", "description", "timeout",
-            "status_file", "outcome_table",
+            "status_file", "outcome_table", "pool",
     ]:
         if arg in add_args and add_args[arg]:
             cmd.append("--%s" % arg.replace("_", "-"))
@@ -393,11 +403,15 @@ def make_litani_exec_command(add_args):
     return " ".join(cmd)
 
 
-def fill_out_ninja(cache, rules, builds):
+def fill_out_ninja(cache, rules, builds, pools):
     phonies = {
         "pipeline_name": {},
         "ci_stage": {},
     }
+
+    for name, depth in cache["pools"].items():
+        pools[name] = depth
+
     for entry in cache["jobs"]:
         outs = entry["outputs"] or []
         ins = entry["inputs"] or []
@@ -406,16 +420,30 @@ def fill_out_ninja(cache, rules, builds):
             description = entry["description"]
         else:
             description = f"Running {entry['command']}..."
+
+        pool_name = entry.get("pool")
+        if pool_name:
+            if pool_name not in pools:
+                logging.error(
+                    "Job '%s' was added to a pool '%s' that was not "
+                    "specified to `litani init`", description, pool_name)
+                sys.exit(1)
+            pool = {"pool": pool_name}
+        else:
+            pool = {}
+
         rule_name = entry["job_id"]
         rules.append({
             "name": rule_name,
             "description": description,
-            "command": make_litani_exec_command(entry)
+            "command": make_litani_exec_command(entry),
+            **pool,
         })
         builds.append({
             "inputs": ins,
             "outputs": outs + [entry["status_file"]],
-            "rule": rule_name
+            "rule": rule_name,
+            **pool,
         })
         if outs:
             for phony in phonies:
@@ -432,6 +460,37 @@ def fill_out_ninja(cache, rules, builds):
                 "outputs": ["__litani_%s_%s" % (phony, job_name)],
                 "rule": "phony",
             })
+
+
+def get_pools(args):
+    ret = {}
+    if not args.pools:
+        return ret
+    for pool in args.pools:
+        pair = pool.split(":")
+        if len(pair) != 2:
+            logging.error(
+                "Cannot parse pool '%s'. The correct format is a space-"
+                "separated list of POOL_NAME:DEPTH", pool)
+            sys.exit(1)
+        name, depth = pair
+        if name in ret:
+            logging.error(
+                "Pool name '%s' given twice (pool names must be unique)", name)
+            sys.exit(1)
+        try:
+            ret[name] = int(depth)
+        except TypeError:
+            logging.error(
+                "Pool depth '%s' cannot be parsed into an int", depth)
+            sys.exit(1)
+
+        if ret[name] < 1:
+            logging.error(
+                "Pool depth cannot be less than 1 for pool '%s'", name)
+            sys.exit(1)
+
+    return ret
 
 
 ################################################################################
@@ -484,6 +543,7 @@ def init(args):
             "run_id": run_id,
             "start_time": now,
             "status": "in_progress",
+            "pools": get_pools(args),
             "jobs": []
         }, indent=2), file=handle)
 
@@ -523,11 +583,15 @@ def run_build(args):
 
     rules = []
     builds = []
-    fill_out_ninja(cache, rules, builds)
+    pools = {}
+    fill_out_ninja(cache, rules, builds, pools)
 
     ninja_file = cache_dir / "litani.ninja"
     with litani.atomic_write(ninja_file) as handle:
         ninja = ninja_syntax.Writer(handle, width=70)
+        for name, depth in pools.items():
+            logging.debug("pool %s: %d", name, depth)
+            ninja.pool(name, depth)
         for rule in rules:
             logging.debug(rule)
             ninja.rule(**rule)


### PR DESCRIPTION
It is now possible to specify a list of job pools, each pool having a
'depth', when running `litani init` using the `--pools` flag.
Individual jobs can then be placed in a pool using the `--pool` flag to
`litani add-job`.

If a pool has a depth D, then only D jobs that are part of that pool
will run in parallel at any given moment, even if the overall
parallelism limit is higher than D. This allows limiting the number of
resource-hungry jobs that are running at once.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
