### PR TITLE
Add --phony-outputs flag

### DIFF
--- a/doc/src/man/litani-add-job.scdoc
+++ b/doc/src/man/litani-add-job.scdoc
@@ -146,6 +146,22 @@ more
 	output in the _stderr_ field of the _run.json_ file. This flag is a useful
 	alternative to using shell redirection (_2>_).
 
+*--phony-outputs* _[OUT ...]_
+	Do not print a warning if this job has not written the named _OUT_ files by
+	the time it finishes running. If you do not specify any _OUT_ files, Litani
+	will not warn when _any_ output specified to the *--outputs* flag does not
+	exist when the job has finished running.
+
+	This is useful when you want to create a dependency ordering between two jobs,
+	but the first job does not write any output files that the second job can
+	depend on. To achieve this, you could pass *--outputs phony-file* when adding
+	the first job, and *--inputs phony-file* when adding the second job. However,
+	Litani will print a warning if the first job exits without writing a file
+	called _phony-file_. To suppress the warning, also pass *--phony-outputs
+	phony-file* when adding the first job. Doing this obviates the need to use
+	touchfiles for dependency ordering, which is how this must be done when using
+	a traditional build system like *make(1)*.
+
 *--pool* _P_
 	Place this job in the pool named _P_. This pool must have been declared using
 	the *--pools* flag of *litani init*. If pool _P_ has a depth of _D_, that

--- a/lib/capabilities.py
+++ b/lib/capabilities.py
@@ -26,6 +26,7 @@ _CAPABILITIES = {
     "memory_profile": "Litani can measure the memory usage of specific jobs",
     "aux": "Run contains an aux field for custom user data",
     "parallelism_metric": "Run contains process parallelism measurements",
+    "phony_outputs": "The --phony-outputs flag is supported",
 }
 
 

--- a/lib/output_artifact.py
+++ b/lib/output_artifact.py
@@ -1,0 +1,52 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+import dataclasses
+import pathlib
+import shutil
+
+
+
+class MissingOutput(Exception):
+    pass
+
+
+
+@dataclasses.dataclass
+class Copier:
+    """Copy output artifacts to a directory, raising if they don't exist"""
+
+    artifacts_dir: pathlib.Path
+    job_args: dict
+
+
+    def copy_output_file(self, fyle):
+        try:
+            shutil.copy(fyle, self.artifacts_dir)
+        except FileNotFoundError as e:
+            if "phony_outputs" not in self.job_args:
+                raise MissingOutput() from e
+
+            if self.job_args["phony_outputs"] is None:
+                raise MissingOutput() from e
+
+            if not self.job_args["phony_outputs"]:
+                # User supplied an empty list of phony outputs, so all outputs
+                # are considered phony
+                return
+
+            if fyle in self.job_args["phony_outputs"]:
+                return
+
+            raise MissingOutput() from e

--- a/lib/validation.py
+++ b/lib/validation.py
@@ -61,6 +61,7 @@ def _get_single_job_arguments():
         "stdout_file": voluptuous.Any(str, None),
         "ok_returns": voluptuous.Any([str], None),
         "outcome_table": voluptuous.Any(str, None),
+        "phony_outputs": voluptuous.Any([str], None),
         "ignore_returns": voluptuous.Any([str], None),
         "subcommand": voluptuous.Any("exec", "add-job"),
     }

--- a/litani
+++ b/litani
@@ -34,6 +34,7 @@ from lib import litani, litani_report, ninja_syntax
 import lib.capabilities
 import lib.graph
 import lib.job_outcome
+import lib.output_artifact
 import lib.ninja
 import lib.process
 import lib.validation
@@ -144,6 +145,11 @@ def get_add_job_args():
             "default": 10,
             "type": int,
             "help": "seconds between memory profile polls"
+        }, {
+            "flags": ["--phony-outputs"],
+            "metavar": "OUT",
+            "nargs": "*",
+            "help": "do not warn if OUT does not exist upon job completion"
         }, {
             "flags": ["--tags"],
             "metavar": "TAG",
@@ -409,7 +415,7 @@ def make_litani_exec_command(add_args):
     # lists
     for arg in [
             "inputs", "outputs", "ignore_returns", "ok_returns",
-            "tags",
+            "tags", "phony_outputs",
     ]:
         if arg not in add_args or add_args[arg] is None:
             continue
@@ -728,14 +734,19 @@ async def exec_job(args):
          out_data["wrapper_arguments"]["pipeline_name"] /
          out_data["wrapper_arguments"]["ci_stage"])
     artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    copier = lib.output_artifact.Copier(
+        artifacts_dir, out_data["wrapper_arguments"])
     for fyle in out_data["wrapper_arguments"]["outputs"] or []:
         try:
-            shutil.copy(fyle, str(artifacts_dir))
-        except FileNotFoundError:
+            copier.copy_output_file(fyle)
+        except lib.output_artifact.MissingOutput:
             logging.warning(
                 "Output file '%s' of pipeline '%s' did not exist upon job "
-                "completion. Not copying to artifacts directory.", fyle,
-            out_data["wrapper_arguments"]["pipeline_name"])
+                "completion. Not copying to artifacts directory. "
+                "If this job is not supposed to emit the file, pass "
+                "`--phony-outputs %s` to suppress this warning", fyle,
+                out_data["wrapper_arguments"]["pipeline_name"], fyle)
         except IsADirectoryError:
             artifact_src = pathlib.Path(fyle)
             try:

--- a/test/unit/output_artifact.py
+++ b/test/unit/output_artifact.py
@@ -1,0 +1,71 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+import shutil
+import pathlib
+import unittest
+import unittest.mock
+
+import lib.output_artifact
+
+
+
+class TestOutputArtifact(unittest.TestCase):
+    def setUp(self):
+        shutil.copy = unittest.mock.Mock(side_effect=FileNotFoundError(""))
+        self.artifacts_dir = pathlib.Path()
+
+
+    def test_no_flag(self):
+        job_args = {}
+        copier = lib.output_artifact.Copier(self.artifacts_dir, job_args)
+
+        with self.assertRaises(lib.output_artifact.MissingOutput):
+            copier.copy_output_file("foo")
+
+
+    def test_null_flag(self):
+        job_args = {
+            "phony_outputs": None,
+        }
+        copier = lib.output_artifact.Copier(self.artifacts_dir, job_args)
+
+        with self.assertRaises(lib.output_artifact.MissingOutput):
+            copier.copy_output_file("foo")
+
+
+    def test_all_phony(self):
+        job_args = {
+            "phony_outputs": [],
+        }
+        copier = lib.output_artifact.Copier(self.artifacts_dir, job_args)
+        copier.copy_output_file("foo")
+
+
+    def test_different_phony(self):
+        job_args = {
+            "phony_outputs": ["bar"],
+        }
+        copier = lib.output_artifact.Copier(self.artifacts_dir, job_args)
+
+        with self.assertRaises(lib.output_artifact.MissingOutput):
+            copier.copy_output_file("foo")
+
+
+    def test_file_phony(self):
+        job_args = {
+            "phony_outputs": ["foo"],
+        }
+        copier = lib.output_artifact.Copier(self.artifacts_dir, job_args)
+        copier.copy_output_file("foo")


### PR DESCRIPTION
This commit introduces a new flag to indicate that one or more of a
job's output files are 'phony', meaning that the job will not actually
write the files upon completion.

By default, Litani warns the user when a job has not written one of its
output files, because this can indicate that the build is incorrect. If
a job does not write its output files, then all dependent jobs will run
unconditionally, making the build unnecessarily slow. However, sometimes
users use outputs merely as a way to create a dependency between two
jobs, even when the first job doesn't actually write the output file. In
this case, the --phony-outputs flag can be used to suppress the warning,
so that only genuinely missing output files generate a warning.

This flag means that users no longer need to write 'touchfiles' upon job
completion to generate a dependency ordering. Instead, they can create
build graphs whose input and output nodes are entirely phony, enabling
the creation of dependency chains without having to manage temporary
files.

This commit fixes #29.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
