### PR TITLE
Add run.json man page & documentation generator

### DIFF
--- a/doc/bin/schema-to-scdoc
+++ b/doc/bin/schema-to-scdoc
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import sys
+
+import jinja2
+import yaml
+
+
+_DESCRIPTION = "Convert a series of commented voluptuous schemas into groff"
+_EPILOG = """
+This program is used to automatically generate documentation for Litani's
+voluptuous schemata. The codebase contains schemata in methods that are preceded
+by the following magic comment:
+
+# doc-gen
+# {
+#   "page": "PAGE_NAME",
+#   "order": N,
+#   "title": "TITLE",
+# }
+
+When this script is run with --page-name PAGE_NAME, it reads all the python
+files in the codebase looking for such blocks with an equal PAGE_NAME. It then
+converts the schema and associated documentation into scdoc format, ready to be
+converted into groff and read in a manual pager.
+"""
+
+
+
+class Comment:
+    def __init__(self, lines):
+        indent_pat = re.compile(r"(?P<indentation>\s*)")
+        match = indent_pat.match(lines[0])
+        self.indent = int(len(match["indentation"]) / 4) - 1
+        self.lines = lines
+
+
+    def print_full(self):
+        return "\n{indentation}{comment}".format(
+            indentation=("\t" * self.indent),
+            comment=" ".join([string.strip()[2:] for string in self.lines]))
+
+
+    def print_compact(self):
+        return ""
+
+
+
+class Code:
+    def __init__(self, line):
+        indent_pat = re.compile(r"^(?P<indentation>\s*)")
+        match = indent_pat.match(line)
+        self.indent = int(len(match["indentation"]) / 4) - 1
+        self.line = self.format_line(line)
+
+
+    def format_line(self, line):
+        line = line.strip()
+        line = re.sub(r"voluptuous\.", "", line)
+        line = re.sub(r"^return\s+", "", line)
+        pat = re.compile(r"(?P<key>.+?):\s+(?P<value>.*?)(?P<end>[^\w]+)$")
+        m = pat.match(line)
+        if m:
+            return "{indentation}{key}: {value} {end}".format(
+                indentation="\t" * self.indent,
+                key=f"*{m['key']}*",
+                value=f"_{m['value']}_" if m['value'] else '',
+                end=m['end'])
+        return "{indentation}{line}".format(
+            indentation="\t" * self.indent,
+            line=line)
+
+
+    def print_compact(self):
+        return self.line
+
+
+    def print_full(self):
+        return self.line
+
+
+
+class Blank:
+    def print_compact(self):
+        return ""
+
+
+    def print_full(self):
+        return "\n"
+
+
+
+def next_line(iterator):
+    try:
+        return next(iterator).rstrip()
+    except StopIteration:
+        return None
+
+
+def get_args():
+    pars = argparse.ArgumentParser(description=_DESCRIPTION, epilog=_EPILOG)
+    for arg in [{
+            "flags": ["--page-name"],
+            "required": True,
+    }, {
+            "flags": ["--project-root"],
+            "required": True,
+    }, {
+            "flags": ["--data-path"],
+            "required": True,
+    }, {
+            "flags": ["--template"],
+            "required": True,
+            "type": pathlib.Path,
+    }]:
+        flags = arg.pop("flags")
+        pars.add_argument(*flags, **arg)
+    return pars.parse_args()
+
+
+def parse_schema(iterator):
+    comment_buf = []
+    ret = []
+
+    line = next_line(iterator)
+    while not (
+            line is None or \
+            line.startswith("def") or \
+            line.startswith("# end-doc-gen")):
+        if line.strip().startswith("# "):
+            comment_buf.append(line)
+        else:
+            if comment_buf:
+                ret.append(Comment(comment_buf))
+                comment_buf = []
+            if not line:
+                ret.append(Blank())
+            else:
+                ret.append(Code(line))
+        line = next_line(iterator)
+    return ret
+
+
+def parse_fun_def(iterator):
+    """Skip the first few lines of a schema function and return the schema"""
+    line = next_line(iterator)
+    while line:
+        line = next_line(iterator)
+    return parse_schema(iterator)
+
+
+def parse_header(iterator, page_name):
+    """Parse the JSON at the top of a single documentation fragment"""
+
+    line = next_line(iterator)
+    buf = []
+    while line is not None:
+        buf.append(line)
+        line = next_line(iterator)
+
+        # { <----- to avoid confusing syntax highlighting
+        if line != "# }":
+            continue
+        buf.append(line)
+        header_str = "\n".join([string[2:] for string in buf])
+        try:
+            header_d = json.loads(header_str)
+        except json.decoder.JSONDecodeError:
+            print(
+                "Could not parse JSON fragment %s" % header_str,
+                file=sys.stderr)
+            sys.exit(1)
+        if header_d["page"] != page_name:
+            return []
+        return [{
+            **header_d,
+            "body": parse_fun_def(iterator)
+        }]
+    return []
+
+
+def parse_file(iterator, page_name):
+    """Return a list of all documentation fragments in a single file"""
+
+    ret = []
+    line = next_line(iterator)
+    while line is not None:
+        if line == "# doc-gen":
+            ret.extend(parse_header(iterator, page_name))
+        line = next_line(iterator)
+    return ret
+
+
+def get_page_fragments(project_root, page_name):
+    ret = []
+    for root, _, fyles in os.walk(project_root):
+        root = pathlib.Path(root)
+        for fyle in fyles:
+            if not fyle.endswith(".py"):
+                continue
+            with open(root / fyle) as handle:
+                ret.extend(parse_file(iter(handle), page_name))
+    return ret
+
+
+def main():
+    args = get_args()
+    fragments = get_page_fragments(args.project_root, args.page_name)
+    fragments.sort(key=lambda x: x["order"])
+
+    with open(args.data_path) as handle:
+        page = yaml.safe_load(handle)
+
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(args.template.parent)),
+        autoescape=jinja2.select_autoescape(
+            enabled_extensions=('html'),
+            default_for_string=True))
+    templ = env.get_template(args.template.name)
+    out = templ.render(page=page, fragments=fragments, page_name=args.page_name)
+    print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/configure
+++ b/doc/configure
@@ -54,21 +54,21 @@ RULES = [{
     "name": "uniquify_header_ids",
     "description": "Giving unique header IDs to ${man-name}.html",
     "command": f"sed -f {BIN_DIR}/uniquify-header-ids"
-                    " -e 's/@MAN_NAME@/${man-name}/g'"
-                    " ${in-file}"
-                    # Get rid of header and footer
-                    " | tail -n +8"
-                    " | tac"
-                    " | tail -n +7"
-                    " | tac"
-                    " > ${out}"
+               " -e 's/@MAN_NAME@/${man-name}/g'"
+               " ${in-file}"
+               # Get rid of header and footer
+               " | tail -n +8"
+               " | tac"
+               " | tail -n +7"
+               " | tac"
+               " > ${out}"
 }, {
     "name": "build_html_doc",
     "description": "Building final HTML page",
     "command": f"{BIN_DIR}/build-html-doc"
-                    "  --html-manuals ${html-mans}"
-                    f" --template-dir {TEMPLATE_DIR}"
-                    "  --out-file ${out}"
+               "  --html-manuals ${html-mans}"
+               f" --template-dir {TEMPLATE_DIR}"
+               "  --out-file ${out}"
 }]
 
 

--- a/doc/configure
+++ b/doc/configure
@@ -50,12 +50,12 @@ RULES = [{
     "name": "voluptuous_to_roff",
     "description": "converting ${man-name} to roff",
     "command": f"{BIN_DIR / 'schema-to-scdoc'}"
-                    f" --project-root { DOC_DIR.parent }"
-                    " --page-name ${man-name}"
-                    " --data-path ${data-path}"
-                    " --template"
-                    f" { TEMPLATE_DIR / 'voluptuous-man.jinja.scdoc' }"
-                    " | scdoc > ${out}"
+               f" --project-root { DOC_DIR.parent }"
+               " --page-name ${man-name}"
+               " --data-path ${data-path}"
+               " --template"
+               f" { TEMPLATE_DIR / 'voluptuous-man.jinja.scdoc' }"
+               " | scdoc > ${out}"
 }, {
     "name": "roff_to_html",
     "description": "converting ${man-name}.roff HTML",

--- a/doc/configure
+++ b/doc/configure
@@ -47,6 +47,16 @@ RULES = [{
     "description": "converting ${man-name} to roff",
     "command": "scdoc < ${in} > ${out}"
 }, {
+    "name": "voluptuous_to_roff",
+    "description": "converting ${man-name} to roff",
+    "command": f"{BIN_DIR / 'schema-to-scdoc'}"
+                    f" --project-root { DOC_DIR.parent }"
+                    " --page-name ${man-name}"
+                    " --data-path ${data-path}"
+                    " --template"
+                    f" { TEMPLATE_DIR / 'voluptuous-man.jinja.scdoc' }"
+                    " | scdoc > ${out}"
+}, {
     "name": "roff_to_html",
     "description": "converting ${man-name}.roff HTML",
     "command": "mandoc -O fragment -Thtml < ${in} > ${out}"
@@ -72,43 +82,59 @@ RULES = [{
 }]
 
 
-def main():
-    builds = []
+def make_html_unique(man, html_man, html_mans, builds):
+    html_unique = HTML_UNIQUE_DIR / f"{man.stem}.html"
+    builds.append({
+        "inputs": [html_man, BIN_DIR / "uniquify-header-ids"],
+        "outputs": [html_unique],
+        "rule": "uniquify_header_ids",
+        "variables": {
+            "man-name": man.stem,
+            "in-file": html_man,
+        }
+    })
+    html_mans.append(html_unique)
 
-    html_mans = []
-    for man in (SRC_DIR / "man").iterdir():
-        roff_out = ROFF_DIR / f"{man.stem}.roff"
+
+def roff_to_html(man, roff_out, builds):
+    html_man = HTML_MAN_SRC_DIR / f"{man.stem}.html"
+    builds.append({
+        "inputs": [roff_out],
+        "outputs": [html_man],
+        "rule": "roff_to_html",
+        "variables": {
+            "man-name": man.stem,
+            "in-file": html_man,
+        }
+    })
+    return html_man
+
+
+def convert_man_dir_to_roff(src_dir, dst_dir, rule, html_mans, builds):
+    for man in (src_dir).iterdir():
+        roff_out = dst_dir / f"{man.stem}.roff"
         builds.append({
             "inputs": [man],
             "outputs": [roff_out],
-            "rule": "sc_to_roff",
+            "rule": rule,
             "variables": {
                 "man-name": man.stem,
+                "data-path": man.resolve(),
             }
         })
+        html_man = roff_to_html(man, roff_out, builds)
+        make_html_unique(man, html_man, html_mans, builds)
 
-        html_man = HTML_MAN_SRC_DIR / f"{man.stem}.html"
-        builds.append({
-            "inputs": [roff_out],
-            "outputs": [html_man],
-            "rule": "roff_to_html",
-            "variables": {
-                "man-name": man.stem,
-            }
-        })
 
-        html_unique = HTML_UNIQUE_DIR / f"{man.stem}.html"
-        builds.append({
-            "inputs": [html_man, BIN_DIR / "uniquify-header-ids"],
-            "outputs": [html_unique],
-            "rule": "uniquify_header_ids",
-            "variables": {
-                "man-name": man.stem,
-                "in-file": html_man,
-            }
-        })
+def main():
+    builds = []
+    html_mans = []
 
-        html_mans.append(html_unique)
+    convert_man_dir_to_roff(
+        SRC_DIR / "man", ROFF_DIR, "sc_to_roff", html_mans, builds)
+    convert_man_dir_to_roff(
+        SRC_DIR / "voluptuous-man", ROFF_DIR, "voluptuous_to_roff", html_mans,
+        builds)
 
     builds.append({
         "inputs": html_mans + [

--- a/doc/src/voluptuous-man/litani-run.json.yaml
+++ b/doc/src/voluptuous-man/litani-run.json.yaml
@@ -1,0 +1,16 @@
+header: > 
+  # SYNOPSIS
+
+  _run.json_: description of a single Litani run
+
+
+  # DESCRIPTION
+
+  Litani writes a _run.json_ file to its cache directory when the user
+  invokes *litani-run-build(1)*. This file contains everything needed to
+  generate the HTML dashboard, with the notable exception of any
+  artefacts that the jobs might emit. (However, Litani does capture
+  jobs' stdout and stderr; any output will be available in _run.json_.)
+  This manual page describes _run.json_ 's format.
+
+footer: ""

--- a/doc/templates/index.jinja.html
+++ b/doc/templates/index.jinja.html
@@ -128,7 +128,8 @@
     min-height: 2em;
   }
   #corner-email {
-    font-family: Helvtica;
+    font-family: Helvetica;
+    font-weight: bold;
     letter-spacing: 2px;
     margin: 0;
     font-size: 28pt;

--- a/doc/templates/voluptuous-man.jinja.scdoc
+++ b/doc/templates/voluptuous-man.jinja.scdoc
@@ -1,0 +1,26 @@
+{{ page_name }}(5) "" "Litani Build System"
+
+{{ page["header"] }}
+
+# SUMMARY
+
+{% for frag in fragments -%}
+## {{ frag["title"] }}
+{% for item in frag["body"] -%}
+{{ item.print_compact() }}
+{% endfor %}{# item in frag["body"] #}
+{% endfor %}{# frag in fragments #}
+
+
+# DETAILED DOCUMENTATION
+
+{% for frag in fragments -%}
+## {{ frag["title"] }}
+{% for item in frag["body"] -%}
+{{ item.print_full() }}
+{% endfor %}{# item in frag["body"] #}
+{% endfor %}{# frag in fragments #}
+
+
+
+{{ page["footer"] }}

--- a/lib/validation.py
+++ b/lib/validation.py
@@ -239,7 +239,7 @@ def _run_schema():
         # Litani's patch version number.
 
         "release_candidate": bool,
-        # false if this version of Litani is a tagged release
+        # false if this version of Litani is a tagged release.
 
         voluptuous.Optional("end_time"): _time_str,
         # The time at which the run ended. This key will only exist if *status*

--- a/lib/validation.py
+++ b/lib/validation.py
@@ -35,43 +35,119 @@ def _time_str(string):
             (string, lib.litani.TIME_FORMAT_R)) from e
 
 
-def _get_single_job_arguments():
+# doc-gen
+# {
+#   "page": "litani-run.json",
+#   "order": 1,
+#   "title": "Schema for 'wrapper_arguments' key"
+# }
+def _single_job_schema():
     import voluptuous
+
+    # The *wrapper_arguments* key to run.json maps to the following dict. None
+    # of the values in this dict change at any point during the run; they are
+    # mostly the same as the flags passed to *litani-add-job(1)* for this job.
     return {
         "job_id": str,
+        # A globally-unique ID for this job.
+
         "command": str,
+        # The command that litani will execute in a subshell.
+
         "ci_stage": str,
+        # The name of the 'stage' that this job will execute in, used for
+        # organizing the HTML dashboard.
+
         "verbose": bool,
+
         "timeout_ok": bool,
+        # If true, then if this job times out, the outcome will be set to
+        # 'success'.
+
         "pipeline_name": str,
+        # The name of the 'pipeline' that this job will execute in, used for
+        # organizing the HTML dashboard.
+
         "very_verbose": bool,
+
         "timeout_ignore": bool,
+        # If true, then if this job times out, the outcome will be set to
+        # 'fail_ignored'.
+
         "profile_memory": bool,
+        # If true, then litani will regularly sample the memory usage of this
+        # job's command while it runs. Samples are stored in the job's
+        # *memory_trace*.
+
         "profile_memory_interval": int,
+        # How frequently (in seconds) litani will profile the command's memory
+        # use, if *profile_memory* is true.
+
         "cwd": voluptuous.Any(str, None),
+        # The directory that litani will run the command in.
+
         "interleave_stdout_stderr": bool,
+        # Whether the command's stderr will be sent to the stdout stream. If
+        # true, the job's *stderr* key will be None and the *stdout* key will
+        # contain lines from both the command's stdout and stderr.
+
         "pool": voluptuous.Any(str, None),
+        # The pool that this job will execute in; if not null, then it must be a
+        # key in the *pools* dict of the overall run.
+
         "tags": voluptuous.Any([str], None),
+        # A list of user-specified tags. Litani mostly doesn't interpret these,
+        # although the HTML dashboard generator does use some of them. Tags are
+        # intended to help users find particular jobs for data analysis and can
+        # contain arbitrary data.
+
         "timeout": voluptuous.Any(int, None),
+        # The number of seconds that Litani will allow the job to run for before
+        # sending SIGTERM followed by SIGKILL (see *signal(3)*).
+
         "inputs": voluptuous.Any([str], None),
+        # The list of files that should be made up-to-date before the job will
+        # run
+
         "outputs": voluptuous.Any([str], None),
+        # The list of files that this job will make up-to-date after it
+        # completes
+
         "description": voluptuous.Any(str, None),
+        # A human-readable description of this job
+
         "status_file": voluptuous.Any(str, None),
+
         "stderr_file": voluptuous.Any(str, None),
+        # A file to redirect stderr to, as well as buffering it internally
+
         "stdout_file": voluptuous.Any(str, None),
+        # A file to redirect stdout to, as well as buffering it internally
+
         "ok_returns": voluptuous.Any([str], None),
+        # A list of return codes. If the command exits with any of these return
+        # codes (or 0), then the outcome will be set to 'success'.
+
         "outcome_table": voluptuous.Any(str, None),
+        # A file to load an outcome table from.
+
         "phony_outputs": voluptuous.Any([str], None),
+        # A list of outputs that Litani will not warn about if they were not
+        # created by the job.
+
         "ignore_returns": voluptuous.Any([str], None),
+        # A list of return codes. If the command exits with any of these return
+        # codes (or 0), then the outcome will be set to 'fail_ignored'.
+
         "subcommand": voluptuous.Any("exec", "add-job"),
+
     }
 
 
 def validate_single_job(job):
     import voluptuous
     import voluptuous.humanize
-    schema = voluptuous.Schema(
-        _get_single_job_arguments(), required=True)
+    schema = voluptuous.Schema(_single_job_schema(), required=True)
     voluptuous.humanize.validate_with_humanized_errors(job, schema)
 
 
@@ -79,76 +155,275 @@ def validate_run(run):
     import voluptuous
     import voluptuous.humanize
     outcome = voluptuous.Any("success", "fail", "fail_ignored")
-    schema = voluptuous.Schema({
-        "aux": dict,
+    schema = voluptuous.Schema(_run_schema(), required=True)
+    voluptuous.humanize.validate_with_humanized_errors(run, schema)
+
+
+# doc-gen
+# {
+#   "page": "litani-run.json",
+#   "order": 3,
+#   "title": "Schema for a job or ci_stage outcome"
+# }
+def _outcome():
+    import voluptuous
+
+    # Outcomes and ci_stages have an *"outcome"* (though, confusingly, the key
+    # is *"status"* for ci_stages). "fail_ignored" means that the job failed but
+    # the user specified that the job's dependencies should run anyway. If a
+    # pipeline contains a job whose outcome is "fail_ignored", then the status
+    # of the pipeline will be "fail" after all of its jobs complete.
+
+    return voluptuous.Any("success", "fail", "fail_ignored")
+# end-doc-gen
+
+# doc-gen
+# {
+#   "page": "litani-run.json",
+#   "order": 2,
+#   "title": "Schema for a pipeline or run status"
+# }
+def _status():
+    import voluptuous
+
+    # pipelines and runs have a *"status"*. The status is "in_progress" when some
+    # of the jobs are incomplete and either "success" or "fail" once all jobs
+    # complete.
+
+    return voluptuous.Any("success", "fail", "in_progress")
+# end-doc-gen
+
+
+# doc-gen
+# {
+#   "page": "litani-run.json",
+#   "order": 0,
+#   "title": "Schema for entire run.json file"
+# }
+def _run_schema():
+    import voluptuous
+
+    # This schema describes Litani's run.json file. *outcome*, *status*, and
+    # *single_job_schema* are sub-schemata that are referenced multiple times
+    # within this schema, and so are defined separately below. All timestamps
+    # are in ISO-8601.
+
+    return {
         "run_id": str,
+        # A globally-unique ID for the run.
+
         "project": str,
+        # A name for the project that this run is part of. This name is used by
+        # the HTML report generator and can be used to group related sets of
+        # runs, but is otherwise not used by litani.
+
         "pools": {voluptuous.Optional(str): int},
+        # A mapping from pool names to the depth of the pool. Jobs can be a
+        # member of zero or one pool. The depth of a pool that a set of jobs
+        # belong to limits the number of those jobs that litani will run in
+        # parallel.
+
         "start_time": _time_str,
-        "version": lib.litani.VERSION,
-        "version_major": lib.litani.VERSION_MAJOR,
-        "version_minor": lib.litani.VERSION_MINOR,
-        "version_patch": lib.litani.VERSION_PATCH,
-        "release_candidate": lib.litani.RC,
+        # The time at which the run started.
+
+        "version": str,
+        # The version string of the Litani binary that ran this run.
+
+        "version_major": int,
+        # Litani's major version number.
+
+        "version_minor": int,
+        # Litani's minor version number.
+
+        "version_patch": int,
+        # Litani's patch version number.
+
+        "release_candidate": bool,
+        # false if this version of Litani is a tagged release
+
         voluptuous.Optional("end_time"): _time_str,
-        "status": voluptuous.Any("in_progress", "fail", "success"),
+        # The time at which the run ended. This key will only exist if *status*
+        # is not equal to "in_progress".
+
+        "status": _status(),
+        # The state of this run, see the status schema below.
+
+        "aux": dict,
+        # A free-form dict that users can add custom information into. There are
+        # no constraints on the format of this dict, but it is recommended that
+        # users add their information to a sub-dict with a key that indicates
+        # its function. For example, to add information pertaining to a CI run,
+        # users might add a key called "continuous_integration_data" whose value
+        # is a sub-dict containing all required fields.
+
         "parallelism": voluptuous.Any({
+        # This dict contains information about the parallelism level of the jobs
+        # that litani runs. This is to measure whether the run is using as many
+        # processor cores as possible over the duration of the run.
+
             voluptuous.Optional("trace"): [{
+            # A list of samples of the run's concurrency level.
+
                 "time": _ms_time_str,
+                # The time at which the sample was taken.
+
                 "finished": int,
+                # How many jobs have finished
+
                 "running": int,
+                # How many jobs are running
+
                 "total": int,
+                # The total number of jobs
+
             }],
+
             voluptuous.Optional("max_parallelism"): int,
+            # The maximum parallelism attained over the run
+
             voluptuous.Optional("n_proc"): voluptuous.Any(None, int),
+            # The number of processors detected on this machine
+
         }),
+
         "pipelines": [{
+        # Each pipeline contains ci_stages which contain jobs.
+
             "url": str,
+
             "name": str,
-            "status": voluptuous.Any("in_progress", "fail", "success"),
+            # The pipeline name. The set of pipeline names are all the names
+            # passed to the --pipeline-name flag of *litani-add-job(1)*.
+
+            "status": _status(),
+            # The pipeline's state, see the status schema below.
+
             "ci_stages": [{
+            # Each ci_stage contains a list of jobs.
+
                 "url": str,
                 "complete": bool,
+                # Whether all the jobs in this stage are complete.
+
                 "name": voluptuous.Any("build", "test", "report"),
-                "status": voluptuous.Any("fail", "fail_ignored", "success"),
+                # The stage's name. In the future, it may be possible for users
+                # to pass arbitrary names here, so it is advisable not to assume
+                # that these are the only three permissable values.
+
+                "status": _outcome(),
+                # The stage's state, see the outcome schema below.
+
                 "progress": voluptuous.All(int, voluptuous.Range(min=0, max=100)),
+
                 "jobs": [voluptuous.Any({
+                # The list of all the jobs in this ci_stage in this pipeline.
+                # There are three different forms the value of this key can
+                # take.
+
                     "complete": False,
-                    "duration_str": voluptuous.Any(str, None),
-                    "wrapper_arguments": _get_single_job_arguments(),
+                    # If *complete* is false and no *start_time* key exists,
+                    # then this job has not yet started.
+
+                    "duration_str": None,
+
+                    "wrapper_arguments": _single_job_schema(),
+                    # The arguments passed to this job, see the
+                    # single_job_schema schema below.
+
                 }, {
                     "complete": False,
+                    # If *complete* is false but the *start_time* key exists,
+                    # then the job has started running but has not yet finished.
+
                     "start_time": _time_str,
-                    "duration_str": voluptuous.Any(str, None),
-                    "wrapper_arguments": _get_single_job_arguments(),
+                    # The time at which the job started running.
+
+                    "duration_str": None,
+
+                    "wrapper_arguments": _single_job_schema(),
+                    # The arguments passed to this job, see the
+                    # single_job_schema schema below.
+
                 }, {
                     "duration": int,
+                    # How long the job ran for.
+
                     "complete": True,
-                    "outcome": outcome,
+                    # If *complete* is true, then the job has terminated.
+
+                    "outcome": _outcome(),
+                    # The job's outcome, see the outcome schema below.
+
                     "end_time": _time_str,
+                    # The time at which the job completed.
+
                     "start_time": _time_str,
+                    # The time at which the job started running.
+
                     "timeout_reached": bool,
+                    # Whether the job reached its timeout limit.
+
                     "command_return_code": int,
+                    # The command's return code.
+
                     "wrapper_return_code": int,
+
                     "stderr": voluptuous.Any([str], None),
+                    # A list of strings that the command printed to its stderr.
+
                     "stdout": voluptuous.Any([str], None),
+                    # A list of strings that the command printed to its stdout.
+
                     "duration_str": voluptuous.Any(str, None),
-                    "wrapper_arguments": _get_single_job_arguments(),
+                    # A human-readable duration of this job (HH:MM:SS).
+
+                    "wrapper_arguments": _single_job_schema(),
+                    # The arguments passed to this job, see the
+                    # single_job_schema schema below.
+
                     "loaded_outcome_dict": voluptuous.Any(dict, None),
+                    # If *wrapper_arguments["outcome_table"]* is not null, the
+                    # value of this key will be the deserialized data loaded
+                    # from the outcome table file.
+
                     "memory_trace": {
+                    # If *profile_memory* was set to true in the wrapper
+                    # arguments for this job, this dict will contain samples of
+                    # the command's memory usage.
+
                         voluptuous.Optional("peak"): {
+                        # The command's peak memory usage.
+
                             "rss": int,
+                            # Peak resident set
+
                             "vsz": int,
+                            # Peak virtual memory size
+
                             "human_readable_rss": str,
+                            # Peak resident set
+
                             "human_readable_vsz": str,
+                            # Peak virtual memory size
+
                         },
+
                         voluptuous.Optional("trace"): [{
+                        # A list of samples of memory usage.
+
                             "rss": int,
+                            # Resident set
+
                             "vsz": int,
+                            # Virtual memory
+
                             "time": _time_str,
-                    }]},
-                })]
-            }]
-        }]
-    }, required=True)
-    voluptuous.humanize.validate_with_humanized_errors(run, schema)
+                            # The time at which the sample was taken
+
+                        }],
+                    },
+                })],
+            }],
+        }],
+    }
+# end-doc-gen


### PR DESCRIPTION
This PR adds parseable comments to the voluptuous schema for the run.json file. This is to allow a man page to be generated from it while staying up-to-date with the executable schema. The PR also adds a `schema-to-scdoc` script that converts the voluptuous schema into scdoc, so that it can then be converted to groff and HTML.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
