### PR TITLE
Add manual chapter numbers to HTML sidebar

### DIFF
--- a/doc/bin/build-html-doc
+++ b/doc/bin/build-html-doc
@@ -21,11 +21,19 @@ import re
 import jinja2
 
 
+CHAPTER_PAT_STR = r'.+"head-ltitle"\>[-\.\w]+\((?P<chap>\d)\)'
+CHAPTER_PAT = re.compile(CHAPTER_PAT_STR)
+
+
 def get_args():
     pars = argparse.ArgumentParser()
     for arg in [{
             "flags": ["--html-manuals"],
             "nargs": "+",
+            "required": True,
+            "type": pathlib.Path,
+    }, {
+            "flags": ["--roff-html-dir"],
             "required": True,
             "type": pathlib.Path,
     }, {
@@ -42,18 +50,35 @@ def get_args():
     return pars.parse_args()
 
 
-def get_manuals(html_manuals):
+def get_manual(man, roff_html_dir):
+    record = {
+        "title": re.sub("litani-", "litani ", man.stem),
+        "anchor": man.stem,
+        "body": [],
+        "chapter": get_chapter(roff_html_dir / man.name),
+    }
+    with open(man) as handle:
+        for line in handle:
+            record["body"].append(line.rstrip())
+    return record
+
+
+def get_chapter(man_html):
+    with open(man_html) as handle:
+        for line in handle:
+            m = CHAPTER_PAT.match(line)
+            if m:
+                return int(m["chap"])
+    raise UserWarning(
+        f"No line of roff html output '{man_html}' matched chapter pattern "
+        f"'{CHAPTER_PAT_STR}'")
+
+
+def get_manuals(html_manuals, roff_html_dir):
     ret = []
     for man in html_manuals:
-        record = {
-            "title": re.sub("litani-", "litani ", man.stem),
-            "anchor": man.stem,
-            "body": [],
-        }
-        with open(man) as handle:
-            for line in handle:
-                record["body"].append(line.rstrip())
-        ret.append(record)
+        if man.stem != "litani":
+            ret.append(get_manual(man, roff_html_dir))
     return ret
 
 
@@ -64,7 +89,7 @@ def main():
         autoescape=jinja2.select_autoescape(
             enabled_extensions=('html'),
             default_for_string=True))
-    manuals = get_manuals(args.html_manuals)
+    manuals = get_manuals(args.html_manuals, args.roff_html_dir)
 
     templ = env.get_template("index.jinja.html")
     page = templ.render(manuals=manuals)

--- a/doc/configure
+++ b/doc/configure
@@ -79,6 +79,7 @@ RULES = [{
                "  --html-manuals ${html-mans}"
                f" --template-dir {TEMPLATE_DIR}"
                "  --out-file ${out}"
+               "  --roff-html-dir ${roff-html-dir}"
 }]
 
 
@@ -145,6 +146,7 @@ def main():
         "rule": "build_html_doc",
         "variables": {
             "html-mans": " ".join([str(h) for h in html_mans]),
+            "roff-html-dir": HTML_MAN_SRC_DIR,
         }
     })
 

--- a/doc/templates/index.jinja.html
+++ b/doc/templates/index.jinja.html
@@ -384,7 +384,9 @@
             </li>
             {% for man in manuals %}
               <li class="navL1">
-								<a href="#litani-man_{{ man["anchor"] }}">{{ man["title"] }}</a>
+								<a
+                  href="#litani-man_{{ man["anchor"] }}"
+                  >{{ man["title"] }}({{ man["chapter"] }})</a>
               </li>
             {% endfor %}{# man in manuals #}
           </ul>


### PR DESCRIPTION
The chapter number of each manual page is now displayed in the sidebar,
using the usual man page convention of man-name(man-chapter). This makes
it more obvious where to browse to when following cross-references
between chapters and makes this convention more prominent for those who
are unfamiliar with it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
