### PR TITLE
Make dump-run more resilient to parallel runs

### DIFF
--- a/doc/src/man/litani-add-job.scdoc
+++ b/doc/src/man/litani-add-job.scdoc
@@ -44,6 +44,14 @@ aspects of the program: timeouts, dealing with return codes, output streams, and
 more
 
 
+# MULTIPROCESS SAFETY
+
+It is safe to run multiple invocations of *litani add-job* in parallel.
+Having a configure script that can run multiple invocations of *litani
+add-job* from a thread pool (or similar) is recommended to decrease
+configure times.
+
+
 # OPTIONS
 
 *--command* _CMD_

--- a/doc/src/man/litani-add-job.scdoc
+++ b/doc/src/man/litani-add-job.scdoc
@@ -186,3 +186,10 @@ more
 *--profile-memory-interval* _N_
 	Profiles the memory usage of this job every _N_ seconds. Has no effect unless
 	*--profile-memory* is also passed.
+
+
+# ENVIRONMENT VARIABLES
+
+*LITANI_JOB_ID*
+	Litani passes the job's unique ID to the command through this environment variable.
+	The unique id is the _job\_id_ field in the *litani-run.json(5)* representation.

--- a/doc/src/man/litani-dump-run.scdoc
+++ b/doc/src/man/litani-dump-run.scdoc
@@ -36,11 +36,22 @@ _run.json_ file in the run's output directory.
 
 This program may be run as a Litani job, and it may be run as a subprocess from
 a command that is part of a Litani job. This allows commands to 'introspect' on
-a Litani run so far. It is guaranteed that if a Litani job runs *litani
+a Litani run so far. It is guaranteed that if a single Litani job runs *litani
 dump-run*, all of the reverse-dependencies of that job will have the
 _"complete"_ key set to *True* in the printed _run.json_ file. That is, any job
 that runs *litani dump-run* will always see the most up-to-date state of the
 build with respect to its own reverse dependencies.
+
+
+# MULTIPROCESS SAFETY
+
+It is safe to run multiple invocations of *litani dump-run* in parallel.
+However, if you do so, the printed result may be slightly out-of-date.
+
+If you run *litani dump-run* from a Litani job, Litani will attempt to ensure
+that the printed run is up-to-date with respect to that job. In particular,
+Litani will try to re-load the run until all the reverse dependencies have their
+_"complete"_ field set to *true*.
 
 
 # OPTIONS

--- a/doc/src/man/litani-init.scdoc
+++ b/doc/src/man/litani-init.scdoc
@@ -39,6 +39,14 @@ find the output directory. Litani will search the following locations for the fi
 
 This allows you to run *litani init* in the 'root' of a project, and subsequently run *litani add-job* further down in the project.
 
+
+# MULTIPROCESS SAFETY
+
+It is safe but pointless to run *litani init* more than once in
+parallel. One of the invocations will 'win', and subsequent invocations
+of *litani add-job* will add jobs to a single run.
+
+
 # OPTIONS
 
 *--project-name* _NAME_

--- a/doc/src/man/litani-run-build.scdoc
+++ b/doc/src/man/litani-run-build.scdoc
@@ -27,6 +27,13 @@ litani run-build [OPTION...]
 This program executes a Litani run. The run must have been created using
 *litani init* and had jobs added to it using *litani add-job*.
 
+
+# MULTIPROCESS SAFETY
+
+It is *NOT SAFE* to run multiple invocations of *litani run-build* in
+parallel.
+
+
 # OPTIONS
 
 *-n*, *--dry-run*

--- a/lib/litani.py
+++ b/lib/litani.py
@@ -26,6 +26,7 @@ import uuid
 CACHE_FILE = "cache.json"
 CACHE_POINTER = ".litani_cache_dir"
 CI_STAGES = ["build", "test", "report"]
+ENV_VAR_JOB_ID = "LITANI_JOB_ID"
 JOBS_DIR = "jobs"
 RUN_FILE = "run.json"
 TIME_FORMAT_R = "%Y-%m-%dT%H:%M:%SZ"

--- a/litani
+++ b/litani
@@ -736,7 +736,8 @@ async def exec_job(args):
 
     run = lib.process.Runner(
         args.command, args.interleave_stdout_stderr, args.cwd,
-        args.timeout, args.profile_memory, args.profile_memory_interval)
+        args.timeout, args.profile_memory, args.profile_memory_interval,
+        args_dict["job_id"])
     await run()
     lib.job_outcome.fill_in_result(run, out_data, args)
 

--- a/test/e2e/tests/dump_run.py
+++ b/test/e2e/tests/dump_run.py
@@ -50,7 +50,7 @@ def get_jobs():
         }
     }, {
         "kwargs": {
-            "command": "sleep 15",
+            "command": "sleep 10",
             "description": "LONG",
             "ci-stage": "build",
             "pipeline": "foo",

--- a/test/e2e/tests/job_id_env.py
+++ b/test/e2e/tests/job_id_env.py
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+def get_init_args():
+    return {
+        "kwargs": {
+            "project": "foo",
+        }
+    }
+
+
+def get_jobs():
+    return [{
+        "kwargs": {
+            "command": "echo $$LITANI_JOB_ID",
+            "ci-stage": "build",
+            "pipeline": "foo",
+        }
+    }]
+
+
+def get_run_build_args():
+    return {}
+
+
+def check_run(run):
+    job = run["pipelines"][0]["ci_stages"][0]["jobs"][0]
+    return job["wrapper_arguments"]["job_id"] == job["stdout"][0].strip()

--- a/test/e2e/tests/multiproc_dump_run.py
+++ b/test/e2e/tests/multiproc_dump_run.py
@@ -1,0 +1,69 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+import json
+import os
+import pathlib
+import sys
+
+
+def get_init_args():
+    return {
+        "kwargs": {
+            "project": "foo",
+        }
+    }
+
+
+def get_jobs():
+    litani_path = pathlib.Path(os.environ["LITANI_E2E_LITANI_PATH"])
+    if not litani_path.exists():
+        raise UserWarning("Could not find litani executable")
+
+    ret = []
+    for i in range(50):
+        ret.extend([{
+            "kwargs": {
+                "command": f"sleep 1",
+                "description": f"sleep-{i}",
+                "outputs": f"output-{i}",
+                "ci-stage": "build",
+                "pipeline": "foo",
+            }
+        }, {
+            "kwargs": {
+                "command":
+                    f"{litani_path} dump-run "
+                    """| jq -e '.. | .jobs? | .[]? """
+                    f"""| .complete or .wrapper_arguments.job_id != "sleep-{i}"'""",
+                "description": f"test-{i}",
+                "inputs": f"output-{i}",
+                "ci-stage": "build",
+                "pipeline": "foo",
+            }
+        }])
+    return ret
+
+
+def get_run_build_args():
+    return {}
+
+
+def check_run(run):
+    pipe = run["pipelines"][0]
+    jobs = pipe["ci_stages"][0]["jobs"]
+    for job in jobs:
+        if not job["outcome"] == "success":
+            return False
+    return True

--- a/test/unit/run_consistency.py
+++ b/test/unit/run_consistency.py
@@ -1,0 +1,178 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+import unittest
+
+import lib.run_printer
+
+
+
+class TestRunConsistency(unittest.TestCase):
+    def setUp(self):
+        self.run = {
+            "pipelines": [{
+                "ci_stages": [{
+                    "jobs": []
+                }]
+            }]
+        }
+
+
+    def add_jobs(self, *jobs):
+        self.run["pipelines"][0]["ci_stages"][0]["jobs"].extend(jobs)
+
+
+    def test_no_id(self):
+        self.add_jobs({
+            "complete": True,
+            "wrapper_arguments": {
+                "job_id": "job 1",
+                "outputs": None,
+                "inputs": None,
+        }}, {
+            "complete": True,
+            "wrapper_arguments": {
+                "job_id": "job 2",
+                "outputs": None,
+                "inputs": None,
+        }})
+
+        with self.assertRaises(lib.run_printer.InconsistentRunError):
+            lib.run_printer.run_consistent_to_job(self.run, "job 3")
+
+
+    def test_found_id(self):
+        self.add_jobs({
+            "complete": False,
+            "wrapper_arguments": {
+                "job_id": "job 1",
+                "outputs": None,
+                "inputs": None,
+        }})
+
+        self.assertTrue(
+            lib.run_printer.run_consistent_to_job(self.run, "job 1"))
+
+
+    def test_reverse_dep_incomplete(self):
+        self.add_jobs({
+            "complete": False,
+            "wrapper_arguments": {
+                "job_id": "job 1",
+                "outputs": ["foo"],
+                "inputs": None,
+        }}, {
+            "complete": False,
+            "wrapper_arguments": {
+                "job_id": "job 2",
+                "outputs": None,
+                "inputs": ["foo"],
+        }})
+
+        with self.assertRaises(lib.run_printer.InconsistentRunError):
+            lib.run_printer.run_consistent_to_job(self.run, "job 2")
+
+
+    def test_reverse_dep_complete(self):
+        self.add_jobs({
+            "complete": True,
+            "wrapper_arguments": {
+                "job_id": "job 1",
+                "outputs": ["foo"],
+                "inputs": None,
+        }}, {
+            "complete": False,
+            "wrapper_arguments": {
+                "job_id": "job 2",
+                "outputs": None,
+                "inputs": ["foo"],
+        }})
+
+        self.assertTrue(
+            lib.run_printer.run_consistent_to_job(self.run, "job 2"))
+
+
+    def test_unrelated_job_ok(self):
+        self.add_jobs({
+            "complete": True,
+            "wrapper_arguments": {
+                "job_id": "job 1",
+                "outputs": ["foo"],
+                "inputs": None,
+        }}, {
+            "complete": False,
+            "wrapper_arguments": {
+                "job_id": "job 2",
+                "outputs": None,
+                "inputs": ["foo"],
+        }}, {
+            "complete": False,
+            "wrapper_arguments": {
+                "job_id": "job 3",
+                "outputs": ["bar"],
+                "inputs": None,
+        }})
+
+        self.assertTrue(
+            lib.run_printer.run_consistent_to_job(self.run, "job 2"))
+
+
+    def test_both_deps_complete(self):
+        self.add_jobs({
+            "complete": True,
+            "wrapper_arguments": {
+                "job_id": "job 1",
+                "outputs": ["foo"],
+                "inputs": None,
+        }}, {
+            "complete": False,
+            "wrapper_arguments": {
+                "job_id": "job 2",
+                "outputs": None,
+                "inputs": ["foo", "bar"],
+        }}, {
+            "complete": True,
+            "wrapper_arguments": {
+                "job_id": "job 3",
+                "outputs": ["bar"],
+                "inputs": None,
+        }})
+
+        self.assertTrue(
+            lib.run_printer.run_consistent_to_job(self.run, "job 2"))
+
+
+    def test_one_of_two_incomplete(self):
+        self.add_jobs({
+            "complete": True,
+            "wrapper_arguments": {
+                "job_id": "job 1",
+                "outputs": ["foo"],
+                "inputs": None,
+        }}, {
+            "complete": False,
+            "wrapper_arguments": {
+                "job_id": "job 2",
+                "outputs": None,
+                "inputs": ["foo", "bar"],
+        }}, {
+            "complete": False,
+            "wrapper_arguments": {
+                "job_id": "job 3",
+                "outputs": ["bar"],
+                "inputs": None,
+        }})
+
+        with self.assertRaises(lib.run_printer.InconsistentRunError):
+            lib.run_printer.run_consistent_to_job(self.run, "job 2")


### PR DESCRIPTION
Previously, if there was a problem reading a dumped run-file, the
dump-run command would wait for one second and try again. Since this
command is inherently racy until we give it a much more sophisticated
implementation (it would really need IPC with the litani run-build
process), this commit should at least make it more reliable when running
it in parallel. The dump-run process now sleeps for a variable amount of
time before attempting to re-load the file; the duration both increases
exponentially and has small random jitters added to it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
