### PR TITLE
Copy cbmc-viewer report directory artifact to final report.

### DIFF
--- a/lib/output_artifact.py
+++ b/lib/output_artifact.py
@@ -41,7 +41,6 @@ class Copier:
             if os.path.isdir(fyle):
                 shutil.copytree(fyle, self.artifacts_dir, dirs_exist_ok=True)
                 return
-            logging.warning("Can't copy %s: expected a file or a directory", fyle)
             raise FileNotFoundError
         except FileNotFoundError as e:
             if "phony_outputs" not in self.job_args:

--- a/lib/output_artifact.py
+++ b/lib/output_artifact.py
@@ -33,7 +33,7 @@ class Copier:
     job_args: dict
 
 
-    def copy_output_file(self, fyle):
+    def copy_output_artifact(self, fyle):
         try:
             if os.path.isfile(fyle):
                 shutil.copy(fyle, self.artifacts_dir)

--- a/litani
+++ b/litani
@@ -770,7 +770,7 @@ async def exec_job(args):
         artifacts_dir, out_data["wrapper_arguments"])
     for fyle in out_data["wrapper_arguments"]["outputs"] or []:
         try:
-            copier.copy_output_file(fyle)
+            copier.copy_output_artifact(fyle)
         except lib.output_artifact.MissingOutput:
             logging.warning(
                 "Output file '%s' of pipeline '%s' did not exist upon job "

--- a/test/unit/output_artifact.py
+++ b/test/unit/output_artifact.py
@@ -32,7 +32,7 @@ class TestOutputArtifact(unittest.TestCase):
         copier = lib.output_artifact.Copier(self.artifacts_dir, job_args)
 
         with self.assertRaises(lib.output_artifact.MissingOutput):
-            copier.copy_output_file("foo")
+            copier.copy_output_artifact("foo")
 
 
     def test_null_flag(self):
@@ -42,7 +42,7 @@ class TestOutputArtifact(unittest.TestCase):
         copier = lib.output_artifact.Copier(self.artifacts_dir, job_args)
 
         with self.assertRaises(lib.output_artifact.MissingOutput):
-            copier.copy_output_file("foo")
+            copier.copy_output_artifact("foo")
 
 
     def test_all_phony(self):
@@ -50,7 +50,7 @@ class TestOutputArtifact(unittest.TestCase):
             "phony_outputs": [],
         }
         copier = lib.output_artifact.Copier(self.artifacts_dir, job_args)
-        copier.copy_output_file("foo")
+        copier.copy_output_artifact("foo")
 
 
     def test_different_phony(self):
@@ -60,7 +60,7 @@ class TestOutputArtifact(unittest.TestCase):
         copier = lib.output_artifact.Copier(self.artifacts_dir, job_args)
 
         with self.assertRaises(lib.output_artifact.MissingOutput):
-            copier.copy_output_file("foo")
+            copier.copy_output_artifact("foo")
 
 
     def test_file_phony(self):
@@ -68,4 +68,4 @@ class TestOutputArtifact(unittest.TestCase):
             "phony_outputs": ["foo"],
         }
         copier = lib.output_artifact.Copier(self.artifacts_dir, job_args)
-        copier.copy_output_file("foo")
+        copier.copy_output_artifact("foo")


### PR DESCRIPTION
Litani was failing to copy the cbmc-viewer report directory to the artifact directory because it was calling shutil.copy on the directory instead of shutil.copytree.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
