### PR TITLE
Print path to report at the end of run-build.

### DIFF
--- a/lib/validation.py
+++ b/lib/validation.py
@@ -144,7 +144,6 @@ def _single_job_schema():
         # codes (or 0), then the outcome will be set to 'fail_ignored'.
 
         "subcommand": voluptuous.Any("exec", "add-job"),
-
     }
 
 
@@ -445,5 +444,8 @@ def _run_schema():
                 })],
             }],
         }],
+
+        "latest_symlink": voluptuous.Any(str, None),
+        # The symbolic link to the report advertised to users
     }
 # end-doc-gen

--- a/litani
+++ b/litani
@@ -602,6 +602,7 @@ async def init(args):
             "pools": get_pools(args),
             "jobs": [],
             "parallelism": {},
+            "latest_symlink": str(latest_symlink),
         }, indent=2), file=handle)
 
     logging.info("cache dir is at: %s", cache_dir)
@@ -716,6 +717,12 @@ async def run_build(args):
     if args.out_file:
         with litani.atomic_write(args.out_file) as handle:
             print(json.dumps(run, indent=2), file=handle)
+
+    # Print the path to the complete report at the end of 'litani run-build'.
+    # The same path was printed at the start of 'litani init'.
+    if 'latest_symlink' in run_info:
+        print("Report was rendered at "
+              f"file://{run_info['latest_symlink']}/html/index.html")
 
     if args.fail_on_pipeline_failure:
         sys.exit(0 if runner.was_successful() else 1)


### PR DESCRIPTION
This causes 'litani run-build' to print the path to the report directory that was printed by 'litani init'.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
