### PR TITLE
Added --no-draw-dependency-graph flag to make graph output optional

### DIFF
--- a/doc/src/man/litani-run-build.scdoc
+++ b/doc/src/man/litani-run-build.scdoc
@@ -25,6 +25,7 @@ litani run-build - Start a Litani run
 	\[*-j*/*--parallel* _N_]
 	\[*-o*/*--out-file* _F_]
 	\[*--fail-on-pipeline-failure*]
+	\[*--no-pipeline-dep-graph*]
 	\[*-p*/*--pipelines* _P_ [_P_ ...]]
 	\[*-s*/*--ci-stage* _S_]
 
@@ -59,6 +60,11 @@ parallel.
 *--fail-on-pipeline-failure*
 	Return _0_ only if all pipelines were successful. See *RETURN CODE*
 	below.
+
+*--no-pipeline-dep-graph*
+	Do not render dependency graphs for each pipeline onto the HTML individual
+	pipeline pages. Pipeline graphs will also not be rendered if Graphviz is
+	not installed.
 
 *-p* _P_ [_P_ ...], *--pipelines* _P_ [_P_ ...]
 	Only run jobs that are part of the specified pipelines.

--- a/lib/litani_report.py
+++ b/lib/litani_report.py
@@ -75,13 +75,13 @@ class Gnuplot:
 
 
 class PipelineDepgraphRenderer:
-    def __init__(self):
-        self.should_render = shutil.which("dot") is not None
-
-        if not self.should_render:
+    def __init__(self, should_render=True):
+        is_graphviz_installed = shutil.which("dot") is not None
+        if not is_graphviz_installed:
             logging.info(
                 "Graphviz is not installed; pipeline dependency "
-                "graph will not be rendered")
+                "graph cannot be rendered")
+        self.should_render = should_render and is_graphviz_installed
 
 
     def render_to_file(self, out_file, pipe):

--- a/litani
+++ b/litani
@@ -304,6 +304,10 @@ def get_args():
             "flags": ["--fail-on-pipeline-failure"],
             "action": "store_true",
             "help": "exit with a non-zero return code if some pipelines failed"
+    }, {
+            "flags": ["--no-pipeline-dep-graph"],
+            "action": "store_true",
+            "help": "do not attempt to generate pipeline dependency graph"
     }]:
         flags = arg.pop("flags")
         run_build_pars.add_argument(*flags, **arg)
@@ -678,11 +682,11 @@ async def run_build(args):
         for build in builds:
             logging.debug(build)
             ninja.build(**build)
-
     report_dir = litani.get_report_dir()
     run = litani_report.get_run_data(cache_dir)
     lib.validation.validate_run(run)
-    pipeline_degraph_renderer = litani_report.PipelineDepgraphRenderer()
+    pipeline_degraph_renderer = litani_report.PipelineDepgraphRenderer(
+        should_render=not args.no_pipeline_dep_graph)
     litani_report.render(run, report_dir, pipeline_degraph_renderer)
     killer = threading.Event()
     render_thread = threading.Thread(


### PR DESCRIPTION
- Runtime with no graph generation took ~1-3 secs less than with graph generation

*Issue #, if available:*
https://github.com/awslabs/aws-build-accumulator/issues/40

*Description of changes:*
Added a **_--no-draw-dependency-graph_** flag to litani run-build to make graph output optional.
Noticed **~1-3secs** less runtime with no graph generation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
