### PR TITLE
Add summary row to HTML dashboard

### DIFF
--- a/lib/litani_report.py
+++ b/lib/litani_report.py
@@ -513,6 +513,19 @@ def get_git_hash():
         return None
 
 
+def get_summary(run):
+    ret = {
+        "in_progress": 0,
+        "success": 0,
+        "total": 0,
+        "fail": 0,
+    }
+    for pipe in run["pipelines"]:
+        ret["total"] += 1
+        ret[pipe["status"]] += 1
+    return ret
+
+
 def render(run, report_dir, pipeline_depgraph_renderer):
     temporary_report_dir = litani.get_report_data_dir() / str(uuid.uuid4())
     temporary_report_dir.mkdir(parents=True)
@@ -540,7 +553,8 @@ def render(run, report_dir, pipeline_depgraph_renderer):
     page = dash_templ.render(
         run=run, svgs=svgs, litani_hash=get_git_hash(),
         litani_version=litani.VERSION,
-        litani_report_archive_path=litani_report_archive_path)
+        litani_report_archive_path=litani_report_archive_path,
+        summary=get_summary(run))
     with litani.atomic_write(temporary_report_dir / "index.html") as handle:
         print(page, file=handle)
 

--- a/templates/dashboard.jinja.html
+++ b/templates/dashboard.jinja.html
@@ -230,6 +230,27 @@ p {
 .graph {
   margin-bottom: 6em;
 }
+
+#pipeline-stats-container {
+  display: flex;
+  margin-left 3em;
+  justify-content: space-evenly;
+}
+.pipeline-single-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.pipeline-single-top {
+  display: flex;
+}
+.pipeline-single-bottom {
+  display: flex;
+  font-size: small;
+  font-variant: small-caps;
+  font-weight: bold;
+}
+
 @media (max-width: 640px){
   .pipeline-progress {
     width: 10em;
@@ -316,6 +337,40 @@ p {
       </div><!-- class="pipeline-link" -->
 
       <div class="pipeline-name">
+        <div id="pipeline-stats-container">
+          <div class="pipeline-single-stat">
+            <div class="pipeline-single-top">
+              <p>{{ summary["fail"] }}</p>
+            </div><!-- class="pipeline-single-top" -->
+            <div class="pipeline-single-bottom">
+              <p>failed</p>
+            </div><!-- class="pipeline-single-top" -->
+          </div><!-- class="pipeline-single-stat" -->
+          <div class="pipeline-single-stat">
+            <div class="pipeline-single-top">
+              <p>{{ summary["in_progress"] }}</p>
+            </div><!-- class="pipeline-single-top" -->
+            <div class="pipeline-single-bottom">
+              <p>in progress</p>
+            </div><!-- class="pipeline-single-top" -->
+          </div><!-- class="pipeline-single-stat" -->
+          <div class="pipeline-single-stat">
+            <div class="pipeline-single-top">
+              <p>{{ summary["success"] }}</p>
+            </div><!-- class="pipeline-single-top" -->
+            <div class="pipeline-single-bottom">
+              <p>succeeded</p>
+            </div><!-- class="pipeline-single-top" -->
+          </div><!-- class="pipeline-single-stat" -->
+          <div class="pipeline-single-stat">
+            <div class="pipeline-single-top">
+              <p>{{ summary["total"] }}</p>
+            </div><!-- class="pipeline-single-top" -->
+            <div class="pipeline-single-bottom">
+              <p>total</p>
+            </div><!-- class="pipeline-single-top" -->
+          </div><!-- class="pipeline-single-stat" -->
+        </div><!-- id="pipeline-stats-container" -->
       </div><!-- class="pipeline-name" -->
 
       <div class="pipeline-progress pipeline-header">


### PR DESCRIPTION
This PR adds a summary row to the HTML dashboard. This includes the following information:
* A summary of the number of failed, in-progress, passed, and total number of pipelines.
* For each CI stage *C*, the total number of pipelines in which all of the jobs for *C* have completed, as well as the number of jobs in *C* that have completed successfully.

This is depicted here:

![Screenshot 2021-10-14 at 01 07 35](https://user-images.githubusercontent.com/2887605/137229246-19df94ae-8934-4fab-9388-05f058fd0953.png)

This allows users to gain an at-a-glance understanding of the run's progress. While pipelines may be 'in progress', there is no equivalent notion for a CI stage; so a run can be considered as succeeding so far if all of the CI stages have an equal number for 'successful' and 'completed'.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
