### PR TITLE
Fix bugs in Graphviz output for pipeline graphs

### DIFF
--- a/lib/graph.py
+++ b/lib/graph.py
@@ -92,21 +92,24 @@ class CommandNode(Node):
 
 
     def __str__(self):
+        if self.description:
+            desc_cell = f"\n<TD><B>{self.description}</B></TD>"
+        else:
+            desc_cell = ""
         return '''"{id}" [label=<
             <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
                 <TR>
-                    <TD><B>{pipeline_name}</B></TD>
-                    <TD><B>{description}</B></TD>
+                    <TD><B>{pipeline_name}</B></TD>{desc_cell}
                 </TR>
                 <TR>
                     <TD COLSPAN="2">{command}</TD>
                 </TR>
             </TABLE>> {style}];'''.format(
-            id=self.id, description = self.description,
-            command = self.command, pipeline_name = self.pipeline_name,
-            style=",".join([
-                f'{key}="{Node.escape(value)}"'
-                for key, value in self.style.items()]))
+                id=self.id, command=self.command, desc_cell=desc_cell,
+                pipeline_name=self.pipeline_name,
+                style=",".join([
+                    f'{key}="{Node.escape(value)}"'
+                    for key, value in self.style.items()]))
 
 
 

--- a/lib/graph.py
+++ b/lib/graph.py
@@ -35,6 +35,20 @@ class Node:
         return string
 
 
+    def html_escape(string):
+        for match, repl in [(
+            '&', '&amp;'
+        ), (
+            '"', '&quot;'
+        ), (
+            '<', '&lt;'
+        ), (
+            '>', '&gt;'
+        )]:
+            string = re.sub(match, repl, string)
+        return string
+
+
 class DependencyNode(Node):
     def __init__(self, fyle, line_width=40, **style):
         self.file = fyle
@@ -70,13 +84,14 @@ class CommandNode(Node):
             self, pipeline_name, description, command, line_width=40, **style):
         self.id = hash(command)
         self.pipeline_name = '<BR/>'.join(
-            textwrap.wrap(pipeline_name, width=line_width))
+            textwrap.wrap(Node.html_escape(pipeline_name), width=line_width))
         if description:
             self.description = '<BR/>'.join(
-                textwrap.wrap(description, width=line_width))
+                textwrap.wrap(Node.html_escape(description), width=line_width))
         else:
             self.description = ""
-        self.command = '<BR/>'.join(textwrap.wrap(command, width=line_width))
+        self.command = '<BR/>'.join(
+            textwrap.wrap(Node.html_escape(command), width=line_width))
         self.style = style
 
         self.style["shape"] = "plain"
@@ -105,7 +120,8 @@ class CommandNode(Node):
                     <TD COLSPAN="2">{command}</TD>
                 </TR>
             </TABLE>> {style}];'''.format(
-                id=self.id, command=self.command, desc_cell=desc_cell,
+                id=self.id, command=self.command,
+                desc_cell=desc_cell,
                 pipeline_name=self.pipeline_name,
                 style=",".join([
                     f'{key}="{Node.escape(value)}"'

--- a/lib/litani_report.py
+++ b/lib/litani_report.py
@@ -92,7 +92,11 @@ class PipelineDepgraphRenderer:
                     ["dot", "-Tsvg"], text=True, stdin=subprocess.PIPE,
                     stdout=handle) as proc:
                 proc.communicate(input=dot_graph)
-        return not proc.returncode
+            if proc.returncode:
+                logging.error("Failed to run dot. Graph: ")
+                logging.error(dot_graph)
+                sys.exit(1)
+        return True
 
 
     def render(self, render_root, pipe_url, pipe):

--- a/test/e2e/tests/html_node.py
+++ b/test/e2e/tests/html_node.py
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+def get_init_args():
+    return {
+        "kwargs": {
+            "project": "foo",
+        }
+    }
+
+
+def get_jobs():
+    return [{
+        "kwargs": {
+            "command": 'echo HTML chars: \& \\\" \< \> >/dev/null',
+            "ci-stage": "build",
+            "pipeline": "foo",
+        }
+    }, {
+        "kwargs": {
+            "command": 'echo HTML chars: \& \\\" \< \> >/dev/null',
+            "description": '" && & < <>> > "',
+            "ci-stage": "build",
+            "pipeline": "foo",
+        }
+    }]
+
+
+def get_run_build_args():
+    return {}
+
+
+def check_run(run):
+    return True


### PR DESCRIPTION
This pull request fixes two syntax errors when rendering pipeline dependency graphs---lack of HTML escaping and empty cells when node descriptions are empty---and ensures that Litani crashes whenever the dot output is incorrect.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
