### PR TITLE
Correctly kill commands that spawn subprocesses

### DIFF
--- a/test/e2e/tests/timed_out_subprocess.py
+++ b/test/e2e/tests/timed_out_subprocess.py
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+def get_init_args():
+    return {
+        "kwargs": {
+            "project": "foo",
+        }
+    }
+
+
+def get_jobs():
+    return [{
+        "kwargs": {
+            "command": """\
+                /usr/bin/python3 -c 'import subprocess; \
+                subprocess.run(["sleep", "10"])' \
+            """,
+            "ci-stage": "build",
+            "pipeline": "foo",
+            "timeout": "3",
+        }
+    }]
+
+
+def get_run_build_args():
+    return {}
+
+
+def check_run(run):
+    job = run["pipelines"][0]["ci_stages"][0]["jobs"][0]
+    return all((job["timeout_reached"], job["duration"] < 5))

--- a/test/e2e/tests/timed_out_subprocess_multi_shell.py
+++ b/test/e2e/tests/timed_out_subprocess_multi_shell.py
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+def get_init_args():
+    return {
+        "kwargs": {
+            "project": "foo",
+        }
+    }
+
+
+def get_jobs():
+    return [{
+        "kwargs": {
+            "command": """\
+                /usr/bin/python3 -c 'import subprocess; \
+                subprocess.run(["sleep", "10"])'; /usr/bin/true \
+            """,
+            "ci-stage": "build",
+            "pipeline": "foo",
+            "timeout": "3",
+        }
+    }]
+
+
+def get_run_build_args():
+    return {}
+
+
+def check_run(run):
+    job = run["pipelines"][0]["ci_stages"][0]["jobs"][0]
+    return all((job["timeout_reached"], job["duration"] < 5))

--- a/test/e2e/tests/timed_out_subprocess_shell.py
+++ b/test/e2e/tests/timed_out_subprocess_shell.py
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+def get_init_args():
+    return {
+        "kwargs": {
+            "project": "foo",
+        }
+    }
+
+
+def get_jobs():
+    return [{
+        "kwargs": {
+            "command": """\
+                python3 -c \"import subprocess; \
+                subprocess.run('sleep 10', shell=True)\" \
+            """,
+            "ci-stage": "build",
+            "pipeline": "foo",
+            "timeout": "3",
+        }
+    }]
+
+
+def get_run_build_args():
+    return {}
+
+
+def check_run(run):
+    job = run["pipelines"][0]["ci_stages"][0]["jobs"][0]
+    return all((job["timeout_reached"], job["duration"] < 5))


### PR DESCRIPTION
This PR changes how Litani executes commands, so that it is
subsequently able to terminate the command and any subprocesses that
the command forks off upon timeout. Prior to this PR, the TERM and
KILL signals were not being propagated to descendant subprocesses,
meaning that these descendant processes would be reparented to init(1)
and continue running without respecting their timeout.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
