### PR TITLE
Do not break command lines in graph output

### DIFF
--- a/lib/graph.py
+++ b/lib/graph.py
@@ -60,7 +60,8 @@ class DependencyNode(Node):
 
         self.style = style
 
-        path_name = "\n".join(textwrap.wrap(path.name, width=line_width))
+        wrapper = get_text_wrapper(line_width)
+        path_name = "\n".join(wrapper.wrap(path.name))
         self.style["label"] = f"{path_name}{ext}"
 
 
@@ -84,15 +85,17 @@ class CommandNode(Node):
     def __init__(
             self, pipeline_name, description, command, line_width=40, **style):
         self.id = hash(command)
+
+        wrapper = get_text_wrapper(line_width)
+
         self.pipeline_name = '<BR/>'.join(
-            textwrap.wrap(Node.html_escape(pipeline_name), width=line_width))
+            wrapper.wrap(Node.html_escape(pipeline_name)))
         if description:
             self.description = '<BR/>'.join(
-                textwrap.wrap(Node.html_escape(description), width=line_width))
+                wrapper.wrap(Node.html_escape(description)))
         else:
             self.description = ""
-        self.command = '<BR/>'.join(
-            textwrap.wrap(Node.html_escape(command), width=line_width))
+        self.command = '<BR/>'.join(wrapper.wrap(Node.html_escape(command)))
         self.style = style
 
         self.style["shape"] = "plain"
@@ -270,6 +273,9 @@ class Graph:
         buf.append("}")
         return "\n".join(buf)
 
+
+def get_text_wrapper(line_width):
+    return textwrap.TextWrapper(width=line_width, break_long_words=False)
 
 
 async def print_graph(args):

--- a/lib/litani_report.py
+++ b/lib/litani_report.py
@@ -54,7 +54,9 @@ class Gnuplot:
         if proc.returncode:
             logging.error("Failed to render gnuplot file:")
             logging.error(gnu_file)
-            sys.exit(1)
+            self._should_render = False
+            return
+
         lines = [
             l for l in out.splitlines()
             if "<?xml version" not in l

--- a/test/e2e/tests/graph_line_break.py
+++ b/test/e2e/tests/graph_line_break.py
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+def get_init_args():
+    return {
+        "kwargs": {
+            "project": "foo",
+        }
+    }
+
+
+def get_jobs():
+    return [{
+        "kwargs": {
+            "command": "echo '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<'",
+            "ci-stage": "build",
+            "pipeline": "foo",
+        }
+    }]
+
+
+def get_run_build_args():
+    return {}
+
+
+def check_run(run):
+    return True


### PR DESCRIPTION
This is because the graph formatting needs to be correct HTML, and we
were sometimes breaking the line in the middle of a multi-character HTML
entity, like &quot;. This commit fixes that so that lines are never
broken in the middle of a word and adds a test that catches this error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
