### PR TITLE
Fix .litani_cache_dir lookup

### DIFF
--- a/lib/litani.py
+++ b/lib/litani.py
@@ -154,10 +154,6 @@ def _get_cache_dir(path=os.getcwd()):
         while current.parent != current:
             current = current.parent
             yield current
-        current = pathlib.Path(os.getcwd()).resolve(strict=True)
-        for root, _, dirs in os.walk(current):
-            for dyr in dirs:
-                yield pathlib.Path(os.path.join(root, dyr))
 
     for possible_dir in cache_pointer_dirs():
         logging.debug(


### PR DESCRIPTION
*Issue #, if available:*
#66 

*Description of changes:*
Removed lookup for `.litani_cache_dir` in subdirectories

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
