### PR TITLE
Fix log statement to not get TypeError exception

### DIFF
--- a/test/run
+++ b/test/run
@@ -27,7 +27,8 @@ def run_cmd(cmd):
     try:
         subprocess.run([str(c) for c in cmd], check=True)
     except subprocess.CalledProcessError:
-        logging.error("Failed to run command '%s'", " ".join(cmd))
+        logging.error(
+            "Failed to run command '%s'", " ".join([str(c) for c in cmd]))
         sys.exit(1)
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The log statement was edited, because the list contains an element of type `PosixPath` (a `TypeError` currently occurs).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
