### PR TITLE
Show running jobs on pipeline page

### DIFF
--- a/lib/graph.py
+++ b/lib/graph.py
@@ -172,8 +172,9 @@ class SinglePipelineGraph:
         for job in self.iter_jobs():
             args = job["wrapper_arguments"]
             cmd_node = self._make_cmd_node(
-                job["complete"], job.get("outcome", None),
-                args["pipeline_name"], args["description"], args["command"])
+                job["complete"], bool(job.get("start_time")), job.get("outcome",
+                None), args["pipeline_name"], args["description"],
+                args["command"])
             self.nodes.add(cmd_node)
 
             for inputt in args.get("inputs") or []:
@@ -188,7 +189,8 @@ class SinglePipelineGraph:
 
 
     @staticmethod
-    def _make_cmd_node(complete, outcome, pipeline_name, description, command):
+    def _make_cmd_node(complete, started, outcome, pipeline_name, description,
+            command):
         cmd_style = {"style": "filled"}
         if complete and outcome == "success":
             cmd_style["fillcolor"] = "#90caf9"
@@ -196,6 +198,11 @@ class SinglePipelineGraph:
             cmd_style["fillcolor"] = "#ffecb3"
         elif complete and outcome == "fail":
             cmd_style["fillcolor"] = "#ef9a9a"
+        elif not complete and started:
+            cmd_style["fillcolor"] = "#ffffff"
+        elif not complete and not started:
+            cmd_style["fillcolor"] = "#bfbfbf"
+            cmd_style["fontcolor"] = "#4d4d4d"
         elif complete:
             raise RuntimeError("Unknown outcome '%s'" % outcome)
         else:

--- a/templates/pipeline.jinja.html
+++ b/templates/pipeline.jinja.html
@@ -73,6 +73,11 @@ p {
   border-radius: 0.3em;
 }
 .command-table .in-progress {
+  background-color: black;
+  padding: 0.3em;
+  border-radius: 0.3em;
+}
+.command-table .non-started {
   background-color: #26323844;
   padding: 0.3em;
   border-radius: 0.3em;
@@ -550,12 +555,14 @@ a:visited:active {
                       1,3 7,8 1,13 3,15 8,9 13,15 15,13 9,8 15,3 13,1 8,7 3,1">
                   </polygon>
                 </svg>
-              {% else %}
+              {% elif not job["complete"] and job.get("start_time") %}
                 <svg height="16px" width="16px" class="status-icon-in-progress">
                   <polygon points="7,8 8,9 9,8 8,1"> </polygon>
                   <polygon points="8,8 8,9 11,11 9,8"> </polygon>
                   <circle cx="8" cy="8" r="7"></circle>
                 </svg>
+              {% else %}
+                <svg height="16px" width="16px"></svg>
               {% endif %}{# job["complete"] #}
             </div><!-- class="toc-row-icon" -->
 
@@ -606,8 +613,10 @@ a:visited:active {
 
     {% for job in stage["jobs"] %}
     <div class="command-table" id="job-{{ job['wrapper_arguments']['job_id'] }}">
-      {% if not job["complete"] %}
+      {% if not job["complete"] and job.get("start_time") %}
       <div class="in-progress">
+      {% elif not job["complete"] %}
+      <div class="not-started">
       {% elif job["outcome"] == "success" %}
       <div class="success">
       {% else %}
@@ -634,8 +643,9 @@ a:visited:active {
             </p>
           </div><!-- class="command-invocation" -->
 
-          {% if job["complete"] %}
+          {% if job.get("start_time") %}
           <div class="command-stats-table">
+            {% if job["complete"] %}
             <div class="command-stats-row">
               <p>Command return code:
               <span class="value">
@@ -692,8 +702,17 @@ a:visited:active {
               {% endif %}{# job["outcome"] == "success"#}
               </span></p>
             </div><!-- class="command-stats-row" -->
+            {% else %}
+              <div class="command-stats-row">
+                <p>Start time:
+                  <span class="value">
+                    {{job["start_time"]}}
+                  </span>
+                </p>
+              </div>
+            {% endif %} {# job["complete"] #}
           </div><!-- class="command-stats-table" -->
-          {% endif %}{# job["complete"] #}
+          {% endif %}{# job.get("start_time") #}
 
           {% if job["complete"] and job["loaded_outcome_dict"] %}
           <div class="outcome-table-info-box">


### PR DESCRIPTION
Distinguish the jobs that are currently running from the jobs that have
not started on the pipeline HTML page. Use CSS to color jobs that are
currently running orange on the dependency graph, border them in orange
on the pipeline page, and only show the in progress icon on running jobs
in the table of contents.

![image](https://user-images.githubusercontent.com/68433946/148280892-65e2a14d-c956-44d5-9e1f-35b5fa189280.png)

![image](https://user-images.githubusercontent.com/68433946/148280947-93815dde-081d-4aa7-bcff-dba5a74195d1.png)

*Issue #, if available:*
#67  

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
