### PR TITLE
Add litani transform-jobs command

### DIFF
--- a/doc/src/man/litani-transform-jobs.scdoc
+++ b/doc/src/man/litani-transform-jobs.scdoc
@@ -1,0 +1,246 @@
+litani-transform-jobs(1) "" "Litani Build System"
+
+; Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+; Licensed under the Apache License, Version 2.0 (the "License").
+; You may not use this file except in compliance with the License.
+; A copy of the License is located at
+
+;     http://www.apache.org/licenses/LICENSE-2.0
+
+; or in the "license" file accompanying this file. This file is distributed
+; on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+; express or implied. See the License for the specific language governing
+; permissions and limitations under the License.
+
+
+# NAME
+
+litani transform-jobs - Print a list of jobs to be modified before running
+
+
+# DESCRIPTION
+
+This program allows clients to add to, delete from, or modify a list of Litani
+jobs before running them. The program prints out all the jobs that have been
+added to the current run so far, and then expects to read a new list of jobs on
+stdin. This new list of jobs will be 'saved' and run upon invocation of
+*litani-run-build(1)*.
+
+This program prints the list of jobs that have been added so far in JSON format.
+It also expects to read a list of jobs as a JSON list. Each job in the list will
+follow the same schema as the elements of the *["jobs"]["wrapper_arguments"]*
+key in the litani _run.json_ file; see *litani-run.json(5)* for the schema. Most
+users will want to run this program before running *litani run-build*, which
+means that none of the jobs will have started; that means that the JSON schema
+will match that of an unstarted job, meaning the *complete* key will be _false_
+and there will be no *start_time* key.
+
+If this program prints a job, and the JSON list written to stdin contains a job
+with the same job id, then Litani will overwrite the original job with the one
+given on stdin. The 'job id' is the value of *["job_id"]* in the job dictionary,
+as specified in *litani-run.json(5)*.
+
+If this program prints a job, but a job with the same job id does not exist in
+the list of jobs written to this program's stdin, then that job will be deleted.
+
+If this program reads a job on stdin whose job id did not exist in the list of
+jobs printed on stdout, then that job will be added to the list of jobs to be
+executed. However, it is _highly recommended_ to add jobs using
+*litani-add-job(1)* rather than adding a new dict to the JSON list. See
+*CAVEATS* below.
+
+
+# MOTIVATION & BEST PRACTICES
+
+This program allows users to modify Litani-based builds that they do not
+control. Litani-based builds typically use a so-called 'run script' to make the
+following Litani invocations:
+
+. *litani init*, once
+. *litani add-job*, for each job to be added
+. *litani run-build*, once
+
+If you cannot modify the run script, you will not have a chance to add custom
+jobs before running them. However, if the run script includes a way to allow
+users to invoke *litani transform-jobs* after step 2 but before step 3, then
+users who cannot modify the run script can nevertheless add their own jobs.
+
+Here are a couple of suggestions for how to write a run script such that
+downstream users can extend your build with additional jobs.
+
+## Add a --job-transformer flag to specify a custom job-transformer program
+
+Suppose that you have a run script called *run.py* that performs the three steps
+above. Consider adding a flag, (we suggest *--job-transformer* _J_) to the
+script. When users pass this flag to *run.py*, it will run _J_ as a subprocess
+after adding all the jobs but just before running *litani run-build*. Users can
+supply their own _J_, which would run *litani transform-jobs* as a subprocess
+and modify jobs as needed.
+
+
+## Add a --no-standalone flag to suppress `litani init' and `litani run-build'
+
+Suppose that you have various run scripts called *run-1.py*, *run-2.py*, *...*
+that each perform the three steps above, but which each add different jobs to
+the build. Suppose you then add a flag (we suggest *--no-standalone*) to each of
+those scripts, which has the effect of preventing them from running *litani
+init* and *litani run-build*. You can then _combine_ the jobs from all of those
+scripts by running them as follows:
+
+```
+$ litani init                     # run this manually in your shell
+$
+$ ./run-1.py --no-standalone      # add the jobs emitted by run-1.py
+$                                 # without re-initializing the build
+$                                 # or running it yet
+$
+$ ./run-2.py --no-standalone      # same for run-2.py. You could also
+$                                 # run these programs in parallel
+$                                 # because it is safe to run parallel
+$                                 # invocations of litani add-job
+
+...
+
+$ ./transform-all-jobs.sh         # This script invokes `litani
+$                                 # transform-jobs` as a subprocess
+$                                 # and modifies the jobs
+$
+$ litani run-build                # run all jobs added from all scripts
+```
+
+This allows users to 'compose' Litani-based builds that they do not have control
+over, and also modify them before running.
+
+
+# MULTIPROCESS SAFETY
+
+It is safe to run this program in parallel with invocations of
+*litani-add-job(1)*, but this usually doesn't make sense; typically you want to
+ensure that your jobs have been added before transforming them. Therefore, wait
+until all invocations of *litani add-job* have terminated before running this
+program. However, see also *CAVEATS* below for when this does make sense.
+
+It is safe to run several invocations of this program at the same time: this
+program always writes jobs out atomically, so an invocation will never read a
+file that has been half-written by another. However, the result of running
+multiple invocations of this program will be unpredictable if the transformation
+is not idempotent, since one invocation may transform a job that has already
+been transformed.
+
+
+# OPTIONS
+
+This program does not accept any command-line options. It does expect to read a
+list of new jobs on stdin, and will block until stdin is closed. To print the
+entire run without modifying any jobs, use *litani-dump-run(1)* instead.
+
+
+# CAVEATS
+
+It is possible to add new jobs using this command, by appending a dict to the
+output of this command and writing the resulting list back to stdin. However,
+this is _not recommended_, because this avoids the error-checking and
+enforcement of internal invariants that *litani-add-job(1)* performs. Thus, it
+is recommended to use *litani-add-job(1)* to add new jobs, either while you
+run *litani transform-jobs*, or after *transform-jobs* terminates.
+
+
+
+# EXAMPLES
+
+This section contains code snippets illustrating how this command can be used.
+
+
+## Running litani transform-jobs
+
+The following Python fragment illustrates how to invoke *litani transform-jobs*
+from a Python script; read the list of jobs; and then write them back to
+*transform-jobs*.
+
+```
+proc = subprocess.Popen(
+        [litani, "-v", "transform-jobs"], stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE, text=True, bufsize=0)
+
+jobs = json.loads(proc.stdout.read())
+
+# jobs is now a list of dicts, which can be processed here
+
+print(json.dumps(jobs), file=proc.stdin)
+proc.stdin.close()
+```
+
+
+## Adding a new root node
+
+Sometimes, you want to add a job that runs before all others. That is, you start
+off with a build graph that looks like this:
+
+```
+foo.exe --> foo.out
+                   \\
+                    \\
+bar.exe --> bar.out --> final.exe --> final.out
+                    /
+                   /
+baz.exe --> baz.out
+```
+
+And you want to print `_echo Starting_` before any job starts to run:
+
+```
+                              foo.exe --> foo.out
+                        ________^                \\
+                       /                          \\
+echo 'Start' --> fake.out --> bar.exe --> bar.out --> final.exe --> final.out
+                      \\________                   /
+                               v                 /
+                              baz.exe --> baz.out
+```
+
+The way to accomplish this is
+
+- Add a new job that emits an output file. The output doesn't have to be a real
+  file; you can use *uuidgen(1)* to get a fresh name. You would add this new job
+  using *litani-add-job(1)*.
+- Use *litani-transform-jobs(1)* to modify the _foo_, _bar_, and _baz_ jobs so
+  that their _"inputs"_ key includes the file that the new job outputs.
+
+These steps can be done in either order. Here is a code example:
+
+```
+proc = subprocess.Popen(
+        [litani, "transform-jobs"], stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE, text=True, bufsize=0)
+
+jobs = json.loads(proc.stdout.read())
+# A file name that the new root job will output, and which the old
+# root nodes will depend on as an input. This is not a real file that
+# the new root command will write, so we'll pass it to --phony-outputs
+# rather than --outputs.
+dependency_node = str(uuid.uuid4())
+
+for job in jobs:
+        if not job["inputs"]:
+            job["inputs"] = [dependency_node]
+
+print(json.dumps(jobs), file=proc.stdin)
+proc.stdin.close()
+
+# Now, add the new root job. (It's also fine to do this before or during the
+# transformation, but remember to skip the new job when iterating!)
+
+subprocess.run([
+        litani, "add-job",
+        "--pipeline", "qux",
+        "--ci-stage", "build",
+        "--command", ">&2 echo Starting && sleep 2",
+        "--phony-outputs", dependency_node,
+], check=True)
+```
+
+
+# SEE ALSO
+
+- *uuidgen(1)*

--- a/doc/templates/index.jinja.html
+++ b/doc/templates/index.jinja.html
@@ -88,6 +88,10 @@
   code {
     font-size: 13pt;
   }
+  pre br {
+    display: block;
+    margin-bottom: -24pt;
+  }
   li {
     padding-left: 0em;
   }

--- a/examples/add-root-node/README
+++ b/examples/add-root-node/README
@@ -1,0 +1,12 @@
+The original-run.sh script runs four jobs---three in parallel, and then
+a final job that depends on the three outputs.
+
+If you cannot modify this script, but want to run a job that runs before
+the first three, you can use *litani-transform-jobs(1)* as show in
+run-all.py.
+
+To try this out, run
+
+    LITANI=../../litani ./run-all.py
+
+in this directory.

--- a/examples/add-root-node/original-run.sh
+++ b/examples/add-root-node/original-run.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+LITANI=${LITANI:-litani}
+
+if [ "$1" != "--no-standalone" ]; then
+  "${LITANI}" init --project-name "project-1"
+fi
+
+
+# 3 parallel jobs, plus a final one that depends on them
+
+
+"${LITANI}" add-job \
+  --command ">&2 echo foo" \
+  --pipeline qux \
+  --ci-stage build \
+  --phony-outputs foo
+
+"${LITANI}" add-job \
+  --command ">&2 echo bar" \
+  --pipeline qux \
+  --ci-stage build \
+  --phony-outputs bar
+
+"${LITANI}" add-job \
+  --command ">&2 echo baz" \
+  --pipeline qux \
+  --ci-stage build \
+  --phony-outputs baz
+
+"${LITANI}" add-job \
+  --command "sleep 1 && >&2 echo Complete" \
+  --pipeline qux \
+  --ci-stage build \
+  --inputs foo bar baz
+
+if [ "$1" != "--no-standalone" ]; then
+  "${LITANI}" run-build
+fi

--- a/examples/add-root-node/run-all.py
+++ b/examples/add-root-node/run-all.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+import logging
+import uuid
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+
+litani = os.getenv("LITANI", "litani")
+this_dir = pathlib.Path(__file__).parent
+
+subprocess.run(
+    [litani, "init", "--project-name", "adding a root job"], check=True)
+
+subprocess.run(
+    [str(this_dir / "original-run.sh"), "--no-standalone"], check=True)
+
+
+# ``````````````````````````````````````````````````````````````````````````````
+# IMPORTANT! bufsize must be 0, otherwise the C stdlib will buffer the jobs that
+# we send back to Litani's stdin
+#
+proc = subprocess.Popen(
+    [litani, "-v", "transform-jobs"], stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE, text=True, bufsize=0)
+
+jobs = json.loads(proc.stdout.read())
+
+# A file name that the new root job will output, and which the old root nodes
+# will depend on as an input. This is not a real file that the new root command
+# will write, so we'll pass it to --phony-outputs rather than --outputs.
+dependency_node = str(uuid.uuid4())
+
+for job in jobs:
+    if not job["inputs"]:
+        job["inputs"] = [dependency_node]
+
+print(json.dumps(jobs), file=proc.stdin)
+proc.stdin.close()
+
+# Now, add the new root job. (It's also fine to do this before or during the
+# transformation, but remember to skip the new job when iterating!)
+
+subprocess.run([
+    litani, "add-job",
+    "--pipeline", "qux",
+    "--ci-stage", "build",
+    "--command", ">&2 echo Starting && sleep 2",
+    "--phony-outputs", dependency_node,
+], check=True)
+
+subprocess.run([litani, "run-build"], check=True)

--- a/examples/no-standalone-transform/README
+++ b/examples/no-standalone-transform/README
@@ -1,0 +1,13 @@
+Each of the run-*.sh scripts in this directory is a standalone Litani-based
+build that runs two jobs: echo "foo" and echo something else.
+
+If you wish to run a single build that contains all the jobs except those that
+print foo, you can run run-all.py, which demonstrates how to use the *litani
+transform-jobs* command. This shows how to modify the jobs to be run, without
+needing to manually tweak the run-*.sh scripts.
+
+To try this out, run
+
+    LITANI=../../litani ./run-all.py
+
+in this directory.

--- a/examples/no-standalone-transform/run-1.sh
+++ b/examples/no-standalone-transform/run-1.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+LITANI=${LITANI:-litani}
+
+if [ "$1" != "--no-standalone" ]; then
+  "${LITANI}" init --project-name "project-1"
+fi
+
+"${LITANI}" add-job \
+  --command ">&2 echo foo" \
+  --pipeline foo \
+  --ci-stage build
+
+"${LITANI}" add-job \
+  --command ">&2 echo bar" \
+  --pipeline foo \
+  --ci-stage build
+
+if [ "$1" != "--no-standalone" ]; then
+  "${LITANI}" run-build
+fi

--- a/examples/no-standalone-transform/run-2.sh
+++ b/examples/no-standalone-transform/run-2.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+LITANI=${LITANI:-litani}
+
+if [ "$1" != "--no-standalone" ]; then
+  "${LITANI}" init --project-name "project-2"
+fi
+
+
+"${LITANI}" add-job \
+  --command ">&2 echo foo" \
+  --pipeline foo \
+  --ci-stage build
+
+"${LITANI}" add-job \
+  --command ">&2 echo baz" \
+  --pipeline foo \
+  --ci-stage build
+
+if [ "$1" != "--no-standalone" ]; then
+  "${LITANI}" run-build
+fi

--- a/examples/no-standalone-transform/run-3.sh
+++ b/examples/no-standalone-transform/run-3.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+LITANI=${LITANI:-litani}
+
+if [ "$1" != "--no-standalone" ]; then
+  "${LITANI}" init --project-name "project-3"
+fi
+
+"${LITANI}" add-job \
+  --command ">&2 echo foo" \
+  --pipeline foo \
+  --ci-stage build
+
+"${LITANI}" add-job \
+  --command ">&2 echo qux" \
+  --pipeline foo \
+  --ci-stage build
+
+if [ "$1" != "--no-standalone" ]; then
+  "${LITANI}" run-build
+fi

--- a/examples/no-standalone-transform/run-all.py
+++ b/examples/no-standalone-transform/run-all.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+import logging
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+
+litani = os.getenv("LITANI", "litani")
+this_dir = pathlib.Path(__file__).parent
+
+subprocess.run(
+    [litani, "init", "--project-name", "jobs from multiple projects"],
+    check=True)
+
+pat = re.compile(r"run-\d.sh")
+for fyle in this_dir.iterdir():
+    if pat.match(fyle.name):
+        subprocess.run([fyle, "--no-standalone"], check=True)
+
+
+# ``````````````````````````````````````````````````````````````````````````````
+# IMPORTANT! bufsize must be 0, otherwise the C stdlib will buffer the jobs that
+# we send back to Litani's stdin
+#
+proc = subprocess.Popen(
+    [litani, "-v", "transform-jobs"], stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE, text=True, bufsize=0)
+
+jobs = json.loads(proc.stdout.read())
+jobs = [j for j in jobs if not j["command"].endswith("foo")]
+
+print(json.dumps(jobs), file=proc.stdin)
+
+
+# ``````````````````````````````````````````````````````````````````````````````
+# IMPORTANT! close "litani transform-jobs"'s stdin, otherwise it will block.
+#
+proc.stdin.close()
+
+subprocess.run([litani, "run-build"], check=True)

--- a/lib/transform_jobs.py
+++ b/lib/transform_jobs.py
@@ -1,0 +1,124 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+import dataclasses
+import json
+import logging
+import os
+import pathlib
+import sys
+
+import lib.litani
+
+
+@dataclasses.dataclass
+class _JobsTransformer:
+    jobs_dir: pathlib.Path
+    old_uuids: list
+
+
+    def __call__(self, user_jobs):
+        for uuid in self.old_uuids:
+            job_file = self.jobs_dir / ("%s.json" % uuid)
+            try:
+                with open(job_file) as handle:
+                    old_job = json.load(handle)
+                    uuid = old_job["job_id"]
+            except FileNotFoundError:
+                logging.warning(
+                    "file for job %s disappeared; not updating", uuid)
+                continue
+
+            updated_job = [
+                j for j in user_jobs if j["job_id"] == uuid
+            ]
+            if not updated_job:
+                self._delete_job(old_job)
+            elif len(updated_job) > 1:
+                logging.error(
+                    "user input contained two jobs with uuid %s", uuid)
+                sys.exit(1)
+            elif updated_job[0] == old_job:
+                self._write_unmodified_job(old_job)
+            else:
+                self._write_transformed_job(updated_job[0])
+
+        new_jobs = [
+            j for j in user_jobs
+            if j["job_id"] not in self.old_uuids]
+        for job in new_jobs:
+            self._write_new_job(job)
+
+
+    @staticmethod
+    def _job_name(job):
+        desc = f" ({job['description']})" if job["description"] else ''
+        return f"{job['job_id']}{desc}"
+
+
+    def _path_to_job(self, job):
+        return self.jobs_dir / ("%s.json" % job["job_id"])
+
+
+    def _write_new_job(self, job):
+        logging.info("writing new job %s", self._job_name(job))
+        with lib.litani.atomic_write(self._path_to_job(job)) as handle:
+            print(json.dumps(job, indent=2), file=handle)
+
+
+    def _write_unmodified_job(self, job):
+        logging.debug("not changing job %s", self._job_name(job))
+
+
+    def _write_transformed_job(self, job):
+        logging.info("transforming job %s", self._job_name(job))
+        with lib.litani.atomic_write(self._path_to_job(job)) as handle:
+            print(json.dumps(job, indent=2), file=handle)
+
+
+    def _delete_job(self, job):
+        logging.info("deleting job %s", self._job_name(job))
+        os.unlink(self._path_to_job(job))
+
+
+
+def _print_jobs(job_paths):
+    out = []
+    for job in job_paths:
+        with open(job) as handle:
+            out.append(json.load(handle))
+    print(json.dumps(out, indent=2))
+    sys.stdout.flush()
+    os.close(sys.stdout.fileno())
+
+
+def _read_jobs():
+    in_text = sys.stdin.read()
+    return json.loads(in_text)
+
+
+async def main(_):
+    jobs_dir = lib.litani.get_cache_dir() / lib.litani.JOBS_DIR
+    old_jobs = list()
+    old_uuids = set()
+    for job in jobs_dir.iterdir():
+        old_jobs.append(job)
+        old_uuids.add(str(job.stem))
+
+    _print_jobs(old_jobs)
+
+    new_jobs = _read_jobs()
+
+    transform = _JobsTransformer(jobs_dir, old_uuids)
+    transform(new_jobs)

--- a/litani
+++ b/litani
@@ -40,6 +40,7 @@ import lib.ninja
 import lib.pid_file
 import lib.process
 import lib.run_printer
+import lib.transform_jobs
 import lib.validation
 
 
@@ -273,6 +274,13 @@ def get_args():
     }]:
         flags = arg.pop("flags")
         graph_pars.add_argument(*flags, **arg)
+
+    transform_jobs_pars = subs.add_parser("transform-jobs",
+        help="print jobs, then read jobs on stdin to save")
+    transform_jobs_pars.set_defaults(func=lib.transform_jobs.main)
+    for arg in []:
+        flags = arg.pop("flags")
+        transform_jobs_pars.add_argument(*flags, **arg)
 
     caps_pars = subs.add_parser("print-capabilities",
         help="Print out Litani's capabilities in a list")

--- a/test/e2e/run
+++ b/test/e2e/run
@@ -79,6 +79,25 @@ def add_jobs(litani, run_dir, mod):
             litani, "add-job", *job.get("args", []), **job.get("kwargs", {}))
 
 
+def transform_jobs(litani, run_dir, mod):
+    os.chdir(run_dir)
+    proc = subprocess.Popen(
+        [litani, "transform-jobs"], stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE, text=True, bufsize=0)
+
+    old_jobs = json.loads(proc.stdout.read())
+    new_jobs = mod.transform_jobs(old_jobs)
+
+    print(json.dumps(new_jobs), file=proc.stdin)
+    proc.stdin.flush()
+    proc.stdin.close()
+
+    proc.wait()
+    if proc.returncode:
+        logging.error("Return code: %d", proc.returncode)
+        sys.exit(1)
+
+
 def run_build(litani, run_dir, mod):
     os.chdir(run_dir)
     args = mod.get_run_build_args()
@@ -109,6 +128,7 @@ OPERATIONS = {
     "add-jobs": add_jobs,
     "run-build": run_build,
     "check-run": check_run,
+    "transform-jobs": transform_jobs,
 }
 
 

--- a/test/e2e/run
+++ b/test/e2e/run
@@ -29,33 +29,6 @@ DESCRIPTION = "Execute a single Litani run and test the resulting run.json"
 EPILOG = "See test/e2e/README for the organization of this test suite"
 
 
-def get_args():
-    pars = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG)
-    for arg in [{
-            "flags": ["--test-file"],
-            "required": True,
-            "type": pathlib.Path,
-            "help": "file under test/e2e/tests containing test definition",
-    }, {
-            "flags": ["--litani"],
-            "required": True,
-            "type": pathlib.Path,
-            "help": "path to Litani under test",
-    }, {
-            "flags": ["--run-dir"],
-            "required": True,
-            "type": pathlib.Path,
-            "help": "a fresh directory in which Litani will be run",
-    }, {
-            "flags": ["--operation"],
-            "required": True,
-            "choices": ["init", "add-jobs", "run-build", "check-run"],
-    }]:
-        flags = arg.pop("flags")
-        pars.add_argument(*flags, **arg)
-    return pars.parse_args()
-
-
 def run_cmd(cmd):
     cmd_list = [str(c) for c in cmd]
     print(" ".join(cmd_list))
@@ -129,6 +102,33 @@ def init(litani, run_dir, mod):
 
 def add_global_context(args):
     os.environ["LITANI_E2E_LITANI_PATH"] = str(args.litani.resolve())
+
+
+def get_args():
+    pars = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG)
+    for arg in [{
+            "flags": ["--test-file"],
+            "required": True,
+            "type": pathlib.Path,
+            "help": "file under test/e2e/tests containing test definition",
+    }, {
+            "flags": ["--litani"],
+            "required": True,
+            "type": pathlib.Path,
+            "help": "path to Litani under test",
+    }, {
+            "flags": ["--run-dir"],
+            "required": True,
+            "type": pathlib.Path,
+            "help": "a fresh directory in which Litani will be run",
+    }, {
+            "flags": ["--operation"],
+            "required": True,
+            "choices": ["init", "add-jobs", "run-build", "check-run"],
+    }]:
+        flags = arg.pop("flags")
+        pars.add_argument(*flags, **arg)
+    return pars.parse_args()
 
 
 def main():

--- a/test/e2e/run
+++ b/test/e2e/run
@@ -104,6 +104,14 @@ def add_global_context(args):
     os.environ["LITANI_E2E_LITANI_PATH"] = str(args.litani.resolve())
 
 
+OPERATIONS = {
+    "init": init,
+    "add-jobs": add_jobs,
+    "run-build": run_build,
+    "check-run": check_run,
+}
+
+
 def get_args():
     pars = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG)
     for arg in [{
@@ -124,7 +132,7 @@ def get_args():
     }, {
             "flags": ["--operation"],
             "required": True,
-            "choices": ["init", "add-jobs", "run-build", "check-run"],
+            "choices": list(OPERATIONS.keys())
     }]:
         flags = arg.pop("flags")
         pars.add_argument(*flags, **arg)
@@ -139,12 +147,7 @@ def main():
 
     mod = get_test_module(args.test_file)
 
-    {
-        "init": init,
-        "add-jobs": add_jobs,
-        "run-build": run_build,
-        "check-run": check_run,
-    }[args.operation](args.litani, args.run_dir, mod)
+    OPERATIONS[args.operation](args.litani, args.run_dir, mod)
 
 
 if __name__ == "__main__":

--- a/test/e2e/tests/transform_delete_job.py
+++ b/test/e2e/tests/transform_delete_job.py
@@ -1,0 +1,53 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+def get_init_args():
+    return {
+        "kwargs": {
+            "project": "foo",
+        }
+    }
+
+
+def get_jobs():
+    return [{
+        "kwargs": {
+            "command": "echo foo",
+            "ci-stage": "build",
+            "pipeline": "foo",
+        }
+    }, {
+        "kwargs": {
+            "command": "echo bar",
+            "ci-stage": "build",
+            "pipeline": "foo",
+        }
+    }]
+
+
+def transform_jobs(jobs):
+    new_jobs = []
+    for job in jobs:
+        if job["command"] != "echo bar":
+            new_jobs.append(job)
+    return new_jobs
+
+
+def get_run_build_args():
+    return {}
+
+
+def check_run(run):
+    jobs = run["pipelines"][0]["ci_stages"][0]["jobs"]
+    return all((len(jobs) == 1, jobs[0]["stdout"][0].strip() == "foo"))

--- a/test/e2e/tests/transform_modify_job.py
+++ b/test/e2e/tests/transform_modify_job.py
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+def get_init_args():
+    return {
+        "kwargs": {
+            "project": "foo",
+        }
+    }
+
+
+def get_jobs():
+    return [{
+        "kwargs": {
+            "command": "echo foo",
+            "ci-stage": "build",
+            "pipeline": "foo",
+        }
+    }]
+
+
+def transform_jobs(jobs):
+    new_jobs = list(jobs)
+    new_jobs[0]["command"] = "echo bar"
+    return new_jobs
+
+
+def get_run_build_args():
+    return {}
+
+
+def check_run(run):
+    job = run["pipelines"][0]["ci_stages"][0]["jobs"][0]
+    return job["stdout"][0].strip() == "bar"

--- a/test/e2e/tests/transform_no_change_job.py
+++ b/test/e2e/tests/transform_no_change_job.py
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+def get_init_args():
+    return {
+        "kwargs": {
+            "project": "foo",
+        }
+    }
+
+
+def get_jobs():
+    return [{
+        "kwargs": {
+            "command": "echo foo",
+            "ci-stage": "build",
+            "pipeline": "foo",
+        }
+    }]
+
+
+def transform_jobs(jobs):
+    return list(jobs)
+
+
+def get_run_build_args():
+    return {}
+
+
+def check_run(run):
+    job = run["pipelines"][0]["ci_stages"][0]["jobs"][0]
+    return job["stdout"][0].strip() == "foo"

--- a/test/run
+++ b/test/run
@@ -79,6 +79,13 @@ def add_e2e_tests(litani, test_dir, counter, output_dir):
         if test_file.name in ["__init__.py", "__pycache__"]:
             continue
 
+        add_transform_jobs = False
+        with open(test_file) as handle:
+            for line in handle:
+                if line.strip().startswith("def transform_jobs("):
+                    add_transform_jobs = True
+                    break
+
         run_dir = output_dir / "e2e_outputs" / str(uuid.uuid4())
 
         litani_add(
@@ -95,6 +102,7 @@ def add_e2e_tests(litani, test_dir, counter, output_dir):
             outputs=run_dir / ".litani_cache_dir",
             cwd=run_dir)
 
+        run_build_input = str(uuid.uuid4())
         litani_add(
             litani, counter,
             command=collapse(f"""
@@ -107,8 +115,26 @@ def add_e2e_tests(litani, test_dir, counter, output_dir):
             ci_stage="test",
             description=f"{test_file.stem}: add jobs",
             inputs=run_dir / ".litani_cache_dir",
-            outputs=f"{run_dir}/output/jobs",
+            phony_outputs=run_build_input,
             cwd=run_dir)
+
+        if add_transform_jobs:
+            add_jobs_output = run_build_input
+            run_build_input = str(uuid.uuid4())
+            litani_add(
+                litani, counter,
+                command=collapse(f"""
+                    {e2e_test_dir / 'run'}
+                    --test-file {test_file}
+                    --litani {litani}
+                    --run-dir {run_dir}
+                    --operation transform-jobs"""),
+                pipeline=f"End-to-end: {test_file.stem}",
+                ci_stage="test",
+                description=f"{test_file.stem}: transform jobs",
+                inputs=add_jobs_output,
+                phony_outputs=run_build_input,
+                cwd=run_dir)
 
         litani_add(
             litani, counter,
@@ -121,7 +147,7 @@ def add_e2e_tests(litani, test_dir, counter, output_dir):
             pipeline=f"End-to-end: {test_file.stem}",
             ci_stage="test",
             description=f"{test_file.stem}: run build",
-            inputs=f"{run_dir}/output/jobs",
+            inputs=run_build_input,
             outputs=f"{run_dir}/output/run.json",
             cwd=run_dir)
 


### PR DESCRIPTION
This PR adds a new command, `litani transform-jobs`, thattransforms the list of added jobs before running the build. This allows users to modify Litani-based builds that they do not control, by first allowing the build to add jobs, then running this command to transform the jobs, then running the build. The PR also adds a working example to a new `examples` subdirectory in the codebase, to illustrate how the command would be used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
