### PR TITLE
Add a --fast option to the Litani test suite

### DIFF
--- a/test/README
+++ b/test/README
@@ -9,3 +9,13 @@ symlinked from test/output/latest/html/index.html.
 
 *--output-dir*
 	Litani will write all of its test output files for this run to this path
+
+*--fast*
+    Do not run tests with SLOW variable set to True
+
+## Writing Tests
+
+Each test is made up of 4 jobs: init, add-jobs, run-build, and check-run
+If --fast flag is passed, each job is given a timeout of 10 seconds.
+In the worst case, a test would take 40 seconds to run.
+For each test, SLOW is set to True if jobs fail to pass the above timeout.

--- a/test/e2e/tests/custom_stages.py
+++ b/test/e2e/tests/custom_stages.py
@@ -1,4 +1,5 @@
 NUM_STAGES = 4
+SLOW = False
 
 def get_stages():
     stages = []

--- a/test/e2e/tests/cwd.py
+++ b/test/e2e/tests/cwd.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = False
 
 def get_init_args():
     return {

--- a/test/e2e/tests/dump_run.py
+++ b/test/e2e/tests/dump_run.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = True
 
 import json
 import os

--- a/test/e2e/tests/graph_line_break.py
+++ b/test/e2e/tests/graph_line_break.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = False
 
 def get_init_args():
     return {

--- a/test/e2e/tests/html_node.py
+++ b/test/e2e/tests/html_node.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = False
 
 def get_init_args():
     return {

--- a/test/e2e/tests/job_id_env.py
+++ b/test/e2e/tests/job_id_env.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = False
 
 def get_init_args():
     return {

--- a/test/e2e/tests/multiproc_dump_run.py
+++ b/test/e2e/tests/multiproc_dump_run.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = True
 
 import json
 import os

--- a/test/e2e/tests/no_pool_serialize.py
+++ b/test/e2e/tests/no_pool_serialize.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = False
 
 def get_init_args():
     return {

--- a/test/e2e/tests/no_pool_serialize_graph.py
+++ b/test/e2e/tests/no_pool_serialize_graph.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = True
 
 def get_init_args():
     return {

--- a/test/e2e/tests/no_timed_out.py
+++ b/test/e2e/tests/no_timed_out.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = False
 
 def get_init_args():
     return {

--- a/test/e2e/tests/no_timed_out_timeout_ignored.py
+++ b/test/e2e/tests/no_timed_out_timeout_ignored.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = False
 
 def get_init_args():
     return {

--- a/test/e2e/tests/no_timed_out_timeout_ok.py
+++ b/test/e2e/tests/no_timed_out_timeout_ok.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = True
 
 def get_init_args():
     return {

--- a/test/e2e/tests/pool_serialize.py
+++ b/test/e2e/tests/pool_serialize.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = True
 
 def get_init_args():
     return {

--- a/test/e2e/tests/pool_serialize_graph.py
+++ b/test/e2e/tests/pool_serialize_graph.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = True
 
 def get_init_args():
     return {

--- a/test/e2e/tests/single_pool.py
+++ b/test/e2e/tests/single_pool.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = False
 
 def get_init_args():
     return {

--- a/test/e2e/tests/timed_out.py
+++ b/test/e2e/tests/timed_out.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = True
 
 def get_init_args():
     return {

--- a/test/e2e/tests/timed_out_subprocess.py
+++ b/test/e2e/tests/timed_out_subprocess.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = True
 
 def get_init_args():
     return {

--- a/test/e2e/tests/timed_out_subprocess_multi_shell.py
+++ b/test/e2e/tests/timed_out_subprocess_multi_shell.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = True
 
 def get_init_args():
     return {

--- a/test/e2e/tests/timed_out_subprocess_shell.py
+++ b/test/e2e/tests/timed_out_subprocess_shell.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = True
 
 def get_init_args():
     return {

--- a/test/e2e/tests/timed_out_timeout_ignored.py
+++ b/test/e2e/tests/timed_out_timeout_ignored.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = True
 
 def get_init_args():
     return {

--- a/test/e2e/tests/timed_out_timeout_ok.py
+++ b/test/e2e/tests/timed_out_timeout_ok.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = True
 
 def get_init_args():
     return {

--- a/test/e2e/tests/transform_delete_job.py
+++ b/test/e2e/tests/transform_delete_job.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = False
 
 def get_init_args():
     return {

--- a/test/e2e/tests/transform_modify_job.py
+++ b/test/e2e/tests/transform_modify_job.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = False
 
 def get_init_args():
     return {

--- a/test/e2e/tests/transform_no_change_job.py
+++ b/test/e2e/tests/transform_no_change_job.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = False
 
 def get_init_args():
     return {

--- a/test/e2e/tests/zero_pool.py
+++ b/test/e2e/tests/zero_pool.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+SLOW = False
 
 def get_init_args():
     return {

--- a/test/run
+++ b/test/run
@@ -15,6 +15,7 @@
 
 
 import argparse
+import importlib
 import logging
 import os
 import pathlib
@@ -33,7 +34,11 @@ def get_args():
             "help": "output dir for test results",
             "default": pathlib.Path(__file__).resolve().parent / "output",
             "type": pathlib.Path
-    }]:
+        }, {
+            "flags": ["--fast"],
+            "help": "run fast tests only",
+            "action": "store_true"
+        }]:
         flags = arg.pop("flags")
         pars.add_argument(*flags, **arg)
     return pars.parse_args()
@@ -45,6 +50,14 @@ def run_cmd(cmd):
     except subprocess.CalledProcessError:
         logging.error(
             "Failed to run command '%s'", " ".join([str(c) for c in cmd]))
+        sys.exit(1)
+
+
+def is_slow_test(module_file):
+    try:
+        return importlib.import_module(str(module_file.stem)).SLOW
+    except AttributeError:
+        logging.error("Variable SLOW is missing from: %s", module_file.name)
         sys.exit(1)
 
 
@@ -69,12 +82,12 @@ def collapse(string):
     return re.sub(r"\s+", " ", string)
 
 
-def add_e2e_tests(litani, test_dir, counter, output_dir):
+def add_e2e_tests(litani, test_dir, counter, output_dir, fast):
     e2e_test_dir = test_dir / "e2e"
     # 4 jobs per test (init, add-jobs, run-build, check-run)
     # skip __init__.py and __pycache__
     counter["total"] += (len(os.listdir(e2e_test_dir / "tests")) - 2) * 4
-
+    sys.path.insert(1, str(e2e_test_dir / "tests"))
     for test_file in (e2e_test_dir / "tests").iterdir():
         if test_file.name in ["__init__.py", "__pycache__"]:
             continue
@@ -85,8 +98,12 @@ def add_e2e_tests(litani, test_dir, counter, output_dir):
                 if line.strip().startswith("def transform_jobs("):
                     add_transform_jobs = True
                     break
+        if fast and is_slow_test(test_file):
+            continue
 
         run_dir = output_dir / "e2e_outputs" / str(uuid.uuid4())
+
+        timeout=10 if fast else 0
 
         litani_add(
             litani, counter,
@@ -100,7 +117,8 @@ def add_e2e_tests(litani, test_dir, counter, output_dir):
             ci_stage="test",
             description=f"{test_file.stem}: init",
             outputs=run_dir / ".litani_cache_dir",
-            cwd=run_dir)
+            cwd=run_dir,
+            timeout=timeout)
 
         run_build_input = str(uuid.uuid4())
         litani_add(
@@ -116,7 +134,9 @@ def add_e2e_tests(litani, test_dir, counter, output_dir):
             description=f"{test_file.stem}: add jobs",
             inputs=run_dir / ".litani_cache_dir",
             phony_outputs=run_build_input,
-            cwd=run_dir)
+            outputs=f"{run_dir}/output/jobs",
+            cwd=run_dir,
+            timeout=timeout)
 
         if add_transform_jobs:
             add_jobs_output = run_build_input
@@ -149,7 +169,8 @@ def add_e2e_tests(litani, test_dir, counter, output_dir):
             description=f"{test_file.stem}: run build",
             inputs=run_build_input,
             outputs=f"{run_dir}/output/run.json",
-            cwd=run_dir)
+            cwd=run_dir,
+            timeout=timeout)
 
         litani_add(
             litani, counter,
@@ -163,7 +184,8 @@ def add_e2e_tests(litani, test_dir, counter, output_dir):
             ci_stage="report",
             description=f"{test_file.stem}: check run",
             inputs=f"{run_dir}/output/run.json",
-            cwd=run_dir)
+            cwd=run_dir,
+            timeout=timeout)
 
 
 def add_unit_tests(litani, test_dir, root_dir, counter):
@@ -186,7 +208,7 @@ def print_counter(counter):
 
 def main():
     args = get_args()
-    logging.basicConfig(format="run-tests: %(message)s")
+    logging.basicConfig(format="\nrun-tests: %(message)s")
     test_dir = pathlib.Path(__file__).resolve().parent
     root = test_dir.parent
     litani = root / "litani"
@@ -208,7 +230,7 @@ def main():
 
     add_unit_tests(litani, test_dir, root, counter)
     add_e2e_tests(
-        litani, test_dir, counter, output_dir=output_dir)
+        litani, test_dir, counter, output_dir, args.fast)
     print()
 
     run_cmd([litani, "run-build"])


### PR DESCRIPTION
- Each Litani end-to-end test has a module-level variable
  called SLOW, set to either True or False
- The test runner should not run SLOW tests if --fast is passed

Fixes #76

*Issue #, if available:*
#76 
*Test changes:*
`./test/run` for default behavior
OR
`./test/run --fast` for running tests with `SLOW=False`

Each test is made up of 4 jobs: init, add-jobs, run-build, and check-run
If --fast flag is passed, the jobs are given the a timeout=10s
For each test, SLOW is set to True is jobs fail to pass the above timeout.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
