### PR TITLE
Do not print error messages from tput when not connected to a tty

### DIFF
--- a/lib/ninja.py
+++ b/lib/ninja.py
@@ -57,6 +57,8 @@ class _OutputAccumulator:
 
     @staticmethod
     def get_tty_width():
+        if os.getenv("TERM") is None:
+            return 80
         try:
             proc = subprocess.run(
                 ["tput", "cols"], text=True, stdout=subprocess.PIPE, check=True)


### PR DESCRIPTION
*Issue #, if available:* #84

*Description of changes:* Litani calls `tput cols` in order to determine the appropriate column width. When the `TERM` environment variable is not set, which is the case for workflows running on Linux-based platforms on continuous integration services like AWS CodeBuild or GitHub actions, then `tput cols` will fail with a message of `tput: No value for $TERM and no -T specified`. In order to avert that error, this change will provide the return-value of `80`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
