### PR TITLE
Inform user that jobs must be added in order for Litani to run a build

### DIFF
--- a/lib/litani.py
+++ b/lib/litani.py
@@ -239,6 +239,11 @@ def add_jobs_to_cache():
     jobs = []
     cache_dir = get_cache_dir()
     jobs_dir = cache_dir / JOBS_DIR
+    if not jobs_dir.exists():
+        logging.error(
+            "Cannot run build: no jobs were added. Run `litani add-job` one or "
+            "more times before running `litani run-build`.")
+        sys.exit(1)
     for job_file in os.listdir(jobs_dir):
         with open(jobs_dir / job_file) as handle:
             jobs.append(json.load(handle))


### PR DESCRIPTION
*Issue #, if available:* Fixes #80

*Description of changes:* 

Previously, running the following:

```bash
python3 litani init --project-name nyx --stages aether
python3 litani run-build
```

would result into a `FileNotFoundError` exception being raised. The traceback mentioned that `No such file or directory exists`. This PR informing users that they must run `litani add-job` one or more times in order for Litani to attempt to run a build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
