### PR TITLE
Prevent file extension from appearing twice in dot dependency diagram

### DIFF
--- a/lib/graph.py
+++ b/lib/graph.py
@@ -56,12 +56,12 @@ class DependencyNode(Node):
         self.id = hash(fyle)
 
         path = pathlib.Path(fyle)
-        _, ext = os.path.splitext(path.name)
+        name, ext = os.path.splitext(path.name)
 
         self.style = style
 
         wrapper = get_text_wrapper(line_width)
-        path_name = "\n".join(wrapper.wrap(path.name))
+        path_name = "\n".join(wrapper.wrap(name))
         self.style["label"] = f"{path_name}{ext}"
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes: #92

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
