### PR TITLE
Add release workflow for litani

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,50 @@
+on:
+  push:
+    tags:
+      - 'litani-*'
+
+name: Create Release
+
+jobs:
+  perform-release:
+    name: Perform Release
+    runs-on: ubuntu-20.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.RELEASE_CI_ACCESS_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Get Version
+        run: echo "VERSION=$(echo ${{ github.ref }} | cut -d "/" -f 3 | cut -d "-" -f 2)" >> $GITHUB_ENV
+      - name: Create release
+        uses: actions/create-release@v1
+        with:
+          tag_name: litani-${{ env.VERSION }}
+          release_name: litani-${{ env.VERSION }}
+          body: |
+            This is Litani version ${{ env.VERSION }}.
+
+            ## MacOS
+
+            On MacOS, install Litani using [Homebrew](https://brew.sh/) with
+
+            ```sh
+            brew install aws/tap/litani
+            ```
+
+            or upgrade (if it's already been installed) with:
+
+            ```sh
+            brew upgrade litani
+            ```
+
+            ## Ubuntu
+
+            On Ubuntu, install Litani by downloading the *.deb package below for Ubuntu 20 and install with
+
+            ```sh
+            # Ubuntu 20.04:
+            $ apt install -y ./litani-${{ env.VERSION }}.deb
+            ```
+          draft: false
+          prerelease: false

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -1,0 +1,86 @@
+on:
+  release:
+    types: [created]
+
+name: Upload additional release assets
+jobs:
+  ubuntu-20_04-package:
+    name: Generate ubuntu-20.04 debian package
+    runs-on: ubuntu-20.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Version
+        run: echo "VERSION=$(echo ${{ github.ref }} | cut -d "/" -f 3 | cut -d "-" -f 2)" >> $GITHUB_ENV
+      - name: Setup directory for deb package
+        run: |
+          sudo apt-get install -y mandoc scdoc ninja-build
+          mkdir -p litani-${{ env.VERSION }}/{DEBIAN,usr/{bin,libexec/litani,share/{doc/litani,man/{man1,man5,man7}}}}
+          touch litani-${{ env.VERSION }}/DEBIAN/control
+          cat << EOF > litani-${{ env.VERSION }}/DEBIAN/control
+          Package: Litani
+          Version: ${{ env.VERSION }}
+          Architecture: amd64
+          Depends: ninja-build, gnuplot, graphviz, python3-jinja2
+          Maintainer: Kareem Khazem <karkhaz@amazon.co.uk>
+          Description: A program that provides platform-independent job control.
+            AWS Build Accumulator collects build jobs from multiple sources before executing
+            them concurrently. It provides platform-independent job control (timeouts,
+            return code control) and an output format that is easy to render into reports
+            (for example, using the built-in renderer). AWS Build Accumulator shines where
+            your project uses multiple different build systems or requires a unified
+            interface describing heterogeneous build jobs.
+          EOF
+          ./doc/configure && ninja
+          mv bin lib templates litani litani-${{ env.VERSION }}/usr/libexec/litani/
+          mv doc/out/man/*.1 litani-${{ env.VERSION }}/usr/share/man/man1
+          mv doc/out/man/*.5 litani-${{ env.VERSION }}/usr/share/man/man5
+          mv doc/out/man/*.7 litani-${{ env.VERSION }}/usr/share/man/man7
+          mv doc/out/html/index.html litani-${{ env.VERSION }}/usr/share/doc/litani
+          ln -s /usr/libexec/litani/litani litani-${{ env.VERSION }}/usr/bin/
+          rm -r $(ls -A | grep -v litani-${{ env.VERSION }})
+      - name: Create .deb package
+        id: create_packages
+        run: |
+          sudo dpkg-deb --build --root-owner-group litani-${{ env.VERSION }}
+          deb_package_name="$(ls *.deb)"
+          echo "::set-output name=deb_package::$deb_package_name"
+          echo "::set-output name=deb_package_name::$deb_package_name"
+      - name: Install Litani using deb package
+        run: sudo apt-get update && sudo apt install -y ./litani-${{ env.VERSION }}.deb
+      - name: Test deb package
+        run: |
+          litani -h
+          man litani
+          litani init --project-name test
+          litani add-job --command '/usr/bin/true' --pipeline-name 'test' --ci-stage test
+          litani run-build
+      - name: Get release
+        id: get_release_info
+        uses: bruceadams/get-release@v1.2.3
+      - name: Upload release binary
+        uses: actions/upload-release-asset@v1.0.2
+        with:
+          upload_url: ${{ steps.get_release_info.outputs.upload_url }}
+          asset_path: ${{ steps.create_packages.outputs.deb_package }}
+          asset_name: ${{ steps.create_packages.outputs.deb_package_name }}
+          asset_content_type: application/x-deb
+
+  homebrew-pr:
+    name: Homebrew Bump Formula PR
+    runs-on: macos-10.15
+    steps:
+      - name: Get release tag name
+        run: echo "RELEASE_TAG=${GITHUB_REF/refs\/tags\/}" >> $GITHUB_ENV
+      - name: Configure git user name and email
+        uses: Homebrew/actions/git-user-config@master
+        with:
+          username: aws-build-accumulator-release-ci
+      - name: Create homebrew PR
+        run: |
+          brew update-reset
+          brew tap aws/tap
+          brew bump-formula-pr --tag "$RELEASE_TAG" --revision "$GITHUB_SHA" aws/tap/litani
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.RELEASE_CI_ACCESS_TOKEN }}


### PR DESCRIPTION
Tests
[Example Release](https://github.com/ronakfof/litani/releases/tag/litani-1.23.4) - [[workflow](https://github.com/ronakfof/litani/runs/5147017859?check_suite_focus=true)]
[Deb package](https://github.com/ronakfof/litani/releases/download/litani-1.23.4/litani-1.23.4.deb) - [[workflow](https://github.com/ronakfof/litani/runs/5147020743?check_suite_focus=true)]
[Example PR to tap](https://github.com/ronakfof/homebrew-litani/pull/11) - [[workflow](https://github.com/ronakfof/litani/runs/5147020632?check_suite_focus=true)]

*Description of changes:*

This workflow gets triggered when a tag is pushed of format `litani-*`.
Bot creates a release for that tag with a boilerplate description.
If a release is created successfully, it also creates a `debian` package for Litani on `ubuntu-20.04`, tests it and uploads it as an additional asset to the release and also create a PR to `aws/tap` with updated `version`, `tag` and `commit`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
