### PR TITLE
Litani dump-run will dump the latest run, if no build is concurrently running

### DIFF
--- a/doc/src/man/litani-dump-run.scdoc
+++ b/doc/src/man/litani-dump-run.scdoc
@@ -31,9 +31,8 @@ This program prints the _run.json_ file for an in-progress Litani run to stdout.
 The JSON file's schema is documented in *litani-run.json(5)*.
 
 This program is intended to be used while an invocation of *litani-run-build(1)*
-is running. After the *run-build* process has terminated, this program will not
-work (though this may change in future versions). Instead, you can access the
-_run.json_ file in the run's output directory.
+is running. You can access the _run.json_ file in the run's output directory
+both during and after termination of the *run-build* process.
 
 This program may be run as a Litani job, and it may be run as a subprocess from
 a command that is part of a Litani job. This allows commands to 'introspect' on

--- a/doc/src/man/litani.scdoc
+++ b/doc/src/man/litani.scdoc
@@ -73,8 +73,8 @@ The following is a synopsis of Litani's subcommands:
 	you ran *litani init*.
 
 *litani dump-run*
-	Print a JSON representation of the run so far to stdout while the
-	build is running.
+	Print a JSON representation of the run so far to stdout both while the
+	build is running as well as after it has completed.
 
 *litani graph*
 	Print the dependency graph of the build in Graphviz format, ready to


### PR DESCRIPTION
*Issue #, if available:*  #69

*Description of changes:*

The `dump-run` command will now dump the latest `run.json` file, assuming one exists.

*Testing:*

I ran:

```bash
python3 litani init --project-name issue-69 && \
python3 litani add-job --command 'sleep 7' --pipeline-name 'smooth-pipeline' --ci-stage build --phony-outputs a-phony-output && \
python3 litani run-build
```

In another terminal I ran: `python3 litani dump-run  > run_tmp.json`
This created a JSON file that matched the `run.json` file present within the folder of the latest run.
I then ran `python3 litani dump-run  > run_tmp_2.json`
The `run_tmp.json` and `run_tmp_2.json` files were identical.
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
