### PR TITLE
Update doc, examples for transform-jobs command

### DIFF
--- a/doc/src/man/litani-transform-jobs.scdoc
+++ b/doc/src/man/litani-transform-jobs.scdoc
@@ -169,6 +169,7 @@ jobs = json.loads(proc.stdout.read())
 
 print(json.dumps(jobs), file=proc.stdin)
 proc.stdin.close()
+proc.wait()
 ```
 
 
@@ -227,6 +228,7 @@ for job in jobs:
 
 print(json.dumps(jobs), file=proc.stdin)
 proc.stdin.close()
+proc.wait()
 
 # Now, add the new root job. (It's also fine to do this before or during the
 # transformation, but remember to skip the new job when iterating!)

--- a/examples/add-root-node/run-all.py
+++ b/examples/add-root-node/run-all.py
@@ -55,6 +55,7 @@ for job in jobs:
 
 print(json.dumps(jobs), file=proc.stdin)
 proc.stdin.close()
+proc.wait()
 
 # Now, add the new root job. (It's also fine to do this before or during the
 # transformation, but remember to skip the new job when iterating!)

--- a/examples/no-standalone-transform/run-all.py
+++ b/examples/no-standalone-transform/run-all.py
@@ -52,7 +52,9 @@ print(json.dumps(jobs), file=proc.stdin)
 
 # ``````````````````````````````````````````````````````````````````````````````
 # IMPORTANT! close "litani transform-jobs"'s stdin, otherwise it will block.
+# This process should wait until all jobs have been transformed
 #
 proc.stdin.close()
+proc.wait()
 
 subprocess.run([litani, "run-build"], check=True)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The docs and examples for the `transform-job` command were updated to include an additional step.
The subprocess running the `transform-jobs` must wait until all jobs have been modified.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
