### PR TITLE
Sort pipelines by status and then name

### DIFF
--- a/lib/litani_report.py
+++ b/lib/litani_report.py
@@ -464,7 +464,7 @@ def sort_run(run):
         pipe["ci_stages"] = stages
         add_pipe_stats(pipe)
         pipelines.append(pipe)
-    pipelines = sorted(pipelines, key=lambda p: p["status"])
+    pipelines = sorted(pipelines, key=lambda p: (p["status"], p["name"]))
     run["pipelines"] = pipelines
     add_run_stats(run)
 

--- a/test/e2e/tests/pipeline_order.py
+++ b/test/e2e/tests/pipeline_order.py
@@ -1,0 +1,53 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+SLOW = True
+EXPECTED_PIPELINE_NAMES = ["zeta", "0", "00", "01", "1", "Beta", "alpha",
+    "beta", "beta1", "beta2", "betaa", "delta", "epsilon", "gamma"]
+
+
+def get_init_args():
+    return {
+        "kwargs": {
+            "project": "sorted_pipeline_names",
+        }
+    }
+
+
+def get_jobs():
+    jobs = []
+    jobs.append({
+        "kwargs": {
+            "command": "/usr/bin/false",
+            "ci-stage": "build",
+            "pipeline": EXPECTED_PIPELINE_NAMES[0],
+        }
+    })
+    for pipeline in EXPECTED_PIPELINE_NAMES[1:]:
+        job = {
+            "kwargs": {
+                "command": "/usr/bin/true",
+                "ci-stage": "build",
+                "pipeline": pipeline,
+            }
+        }
+        jobs.append(job)
+    return jobs
+
+
+def get_run_build_args():
+    return {}
+
+
+def check_run(run):
+    return [p["name"] for p in run["pipelines"]] == EXPECTED_PIPELINE_NAMES


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Name will now be used as the second criterion when sorting pipelines.

The order with which pipelines appear in both the HTML dashboard is the same as
the order with which they appear in the run.json. An e2e test was added to 
ensure that the order is indeed the intended one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
