### PR TITLE
Add --out-file flag to litani-dump-run

### DIFF
--- a/doc/src/man/litani-dump-run.scdoc
+++ b/doc/src/man/litani-dump-run.scdoc
@@ -22,12 +22,13 @@ litani dump-run - Print the current run as a JSON document to stdout
 # SYNOPSIS
 
 *litani dump-run*
-	\[*--retries* _N_]
+	\[*-r*/*--retries* _N_]
+	\[*-o*/*--out-file* _F_]
 
 
 # DESCRIPTION
 
-This program prints the _run.json_ file for an in-progress Litani run to stdout.
+This program prints the run.json file for a Litani run to stdout or to the specified output file.
 The JSON file's schema is documented in *litani-run.json(5)*.
 
 This program is intended to be used while an invocation of *litani-run-build(1)*
@@ -62,6 +63,8 @@ _"complete"_ field set to *true*.
 	every second up to the limit given in this flag. If _N_ is *0*, this program
 	will retry indefinitely---this is not recommended.
 
+*-o* _F_, *--out-file* _F_
+	Print the run to _F_ instead of stdout
 
 # OUTPUT
 

--- a/litani
+++ b/litani
@@ -260,6 +260,11 @@ def get_args():
             "help":
                 "how many times to retry loading the run in 1 second intervals"
                 " (Default: %(default)s)"
+        }, {
+            "flags": ["-o", "--out-file"],
+            "metavar": "F",
+            "type": _non_directory_path,
+            "help": "Output file to dump run file in"
     }]:
         flags = arg.pop("flags")
         dump_run_pars.add_argument(*flags, **arg)
@@ -414,6 +419,14 @@ def non_negative_int(arg):
         raise argparse.ArgumentTypeError(
             "Timeout '%d' must be >= 0" % ret) from e
     return ret
+
+
+def _non_directory_path(arg):
+    path = pathlib.Path(arg)
+    if path.exists() and path.is_dir():
+        raise ValueError(
+          f"--out-file flag expects a file and not a directory: {arg}")
+    return path
 
 
 def list_of_ints(arg):


### PR DESCRIPTION
With this commit, users can now dump run files to a file by passing
--out-file flag with the file path to litani dump-run.

Fixes #110

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
