### PR TITLE
Add ids to sections on HTML dashboard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+Contributing
+============
+
+Thank you for contributing to Litani! This document collects some coding and
+process guidelines.
+
+
+### HTML Dashboard
+
+- Please test your changes with both light and dark mode, and with a range of
+  browser widths.
+- Almost all top-level divs should have an id attribute; this makes it easy to
+  link to specific information.
+- We prefer to inline all assets (CSS, images) onto the page so that it's easy
+  to send single, self-contained pages around. For this reason, please try to
+  keep SVGs small.

--- a/templates/dashboard.jinja.html
+++ b/templates/dashboard.jinja.html
@@ -426,7 +426,7 @@ p {
     </div><!-- class="pipeline-row" -->
 
     {% for pipe in run["pipelines"] %}
-    <div class="pipeline-row">
+    <div class="pipeline-row" id="pipe_row_{{ pipe['name'] }}">
 
       <div class="pipeline-link">
             <svg height="16px" width="32px" class="pipeline-icon">
@@ -496,7 +496,9 @@ p {
         <h2>Job Outputs</h2>
       </div>
       {% for job_desc, job in front_page_outputs.items() %}
-        <div class="job-output-content">
+        <div
+            class="job-output-content"
+            id="job_front_page_output_{{ job['wrapper_arguments']['job_id']}}">
           <div class="job-output-title">
             <h3>Output of job &quot;<a
               href="pipelines/{{ job['wrapper_arguments']['pipeline_name'] }}/
@@ -515,7 +517,9 @@ index.html#job-{{ job['wrapper_arguments']['job_id'] }}"
 
   {% for title, svg_list in svgs.items() %}
     {% if svg_list %}
-      <h2 class="downloads-header">{{ title }}</h2>
+      <h2
+          class="downloads-header"
+          id="svg_{{ title }}">{{ title }}</h2>
       <div class="graphs">
       {% for svg in svg_list %}
         <div class="graph">
@@ -529,7 +533,7 @@ index.html#job-{{ job['wrapper_arguments']['job_id'] }}"
   {% endfor -%}{# title, svg_list in svgs #}
 
 
-  <h2 class="downloads-header">Downloads</h2>
+  <h2 class="downloads-header" id="downloads">Downloads</h2>
   <div class="downloads">
     <ul>
       <li>
@@ -549,7 +553,7 @@ index.html#job-{{ job['wrapper_arguments']['job_id'] }}"
     </ul>
   </div>
 
-  <div class="footer">
+  <div class="footer" id="footer">
     <div class="footer-cell">
       <p>
         Report generated with


### PR DESCRIPTION
Every major section on the HTML dashboard now has an "id" attribute,
making it possible to link to those sections. Prior to this commit, it
was not possible to link to specific graphs on the front page, for
example. This PR also introduces a CONTRIBUTING.md file that contains
guidance to continue this pattern.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
