### PR TITLE
Fix content colour in dark mode

### DIFF
--- a/templates/dashboard.jinja.html
+++ b/templates/dashboard.jinja.html
@@ -302,9 +302,6 @@ p {
   .status-icon-in-progress { fill: #ddd; }
   .status-icon-in-progress circle { stroke: #ddd; }
 
-  .pipeline-header {
-    color: #eceff1;
-  }
   .downloads-header {
     color: #eceff1;
   }
@@ -325,15 +322,11 @@ p {
     color: #eceff1;
   }
   .pipeline-row {
-    color: #eceff1;
     background-color: #37474f;
   }
-  body {
+  content {
     color: #babdbe;
     background-color: #263238;
-  }
-  p {
-    color: #babdbe;
   }
   #subtitle {
     color: #fff;


### PR DESCRIPTION
Previously, some content would appear in a dark colour in dark mode
because the "color" property was set in the .content class for light
mode but the <body> element for dark mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
