### PR TITLE
Print out stderr when a job fails

### DIFF
--- a/litani
+++ b/litani
@@ -772,6 +772,11 @@ async def exec_job(args):
             with litani.atomic_write(arg_file) as handle:
                 print(out_str, file=handle)
 
+    if out_data["wrapper_return_code"] and out_data["stderr"]:
+        print(
+            "\n".join([l.rstrip() for l in out_data["stderr"]]),
+            file=sys.stderr)
+
     timestamp("end_time", out_data)
     out_str = json.dumps(out_data, indent=2)
     logging.debug("run status: %s", out_str)


### PR DESCRIPTION
The entire buffered stderr of a job that fails will now be printed to
the terminal after the failing command line. This is to help users
quickly debug these jobs without viewing the HTML report.

This commit fixes #131.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
