### PR TITLE
Add command to get html directory

### DIFF
--- a/doc/src/man/litani-get-html-dir.scdoc
+++ b/doc/src/man/litani-get-html-dir.scdoc
@@ -1,0 +1,54 @@
+litani-dump-run(1) "" "Litani Build System"
+
+; Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+; Licensed under the Apache License, Version 2.0 (the "License").
+; You may not use this file except in compliance with the License.
+; A copy of the License is located at
+
+;     http://www.apache.org/licenses/LICENSE-2.0
+
+; or in the "license" file accompanying this file. This file is distributed
+; on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+; express or implied. See the License for the specific language governing
+; permissions and limitations under the License.
+
+
+# NAME
+
+litani get-html-dir - Returns the path to html directory of latest run.
+
+
+# SYNOPSIS
+
+*litani dump-run*
+	\[*-d*/*--display*]
+
+
+# DESCRIPTION
+
+This program prints the path to html directory of latest run.
+
+
+# MULTIPROCESS SAFETY
+
+It is safe to run multiple invocations of *litani get-html-dir* in parallel.
+However, if you do so, the printed result may be slightly out-of-date.
+
+If you run *litani get-html-dir* from a Litani job, Litani will attempt to ensure
+that the printed run is up-to-date with respect to that job.
+
+
+# OPTIONS
+
+*-d*, *--display*
+	Print the path to html directory to stdout.
+
+# OUTPUT
+
+A PATH printed to stdout.
+
+
+# RETURN CODE
+
+Zero unless the program crashed.

--- a/doc/src/man/litani.scdoc
+++ b/doc/src/man/litani.scdoc
@@ -84,6 +84,9 @@ The following is a synopsis of Litani's subcommands:
 	Print a list of features that this version of Litani supports. This
 	can be used as an alternative to checking the version string.
 
+*litani get-html-dir*
+	Returns the path to html directory of latest run.
+
 
 # SEE ALSO
 

--- a/lib/litani.py
+++ b/lib/litani.py
@@ -193,6 +193,13 @@ def get_report_dir():
     return get_cache_dir() / "html"
 
 
+async def get_html_dir(args):
+    html_dir = get_report_dir()
+    if args.display:
+        print(html_dir)
+    return html_dir
+
+
 def get_report_data_dir():
     return get_cache_dir() / "report_data"
 

--- a/litani
+++ b/litani
@@ -357,6 +357,16 @@ def get_args():
             flags = arg.pop("flags")
             group.add_argument(*flags, **arg)
 
+    get_html_dir_pars = subs.add_parser("get-html-dir")
+    get_html_dir_pars.set_defaults(func=lib.litani.get_html_dir)
+    for arg in [{
+            "flags": ["-d", "--display"],
+            "action": "store_true",
+            "help": "Print path of html dir to stdout"
+        }]:
+        flags = arg.pop("flags")
+        get_html_dir_pars.add_argument(*flags, **arg)
+
     all_args = sys.argv[1:]
     wrapped_command = None
     if "--" in all_args:


### PR DESCRIPTION
*Issue #, if available:*
#101

*Description of changes:*
This pull request adds a a new command [`litani get-html-dir`] to litani to fetch `html-dir` of latest run.

*Test*
Checkout this Pull Request and run -
```
./litani init --project-name test
./litani add-job --command /usr/bin/true --pipeline-name test --ci-stage test
./litani run-build

# Print html-dir to stdout
./litani get-html-dir --display
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
