### PR TITLE
Upload report as artifact on test failure

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -16,5 +16,18 @@ jobs:
         run: |
           brew install ninja
           python3 -m pip install jinja2
+
       - name: Run Unit and e2e tests
         run: ./test/run
+        continue-on-error: true
+        timeout-minutes: 5
+
+      - name: Get absolute path to report dir
+        run: echo "REPORT_PATH=$(readlink test/output/latest/html)" >> $GITHUB_ENV
+
+      - name: Upload report as artifact
+        uses: actions/upload-artifact@main
+        if: always()
+        with:
+          name: Report
+          path: ${{ env.REPORT_PATH }}

--- a/test/run
+++ b/test/run
@@ -113,7 +113,7 @@ def add_e2e_tests(litani, test_dir, counter, output_dir, fast):
                 --litani {litani}
                 --run-dir {run_dir}
                 --operation init"""),
-            pipeline=f"End-to-end: {test_file.stem}",
+            pipeline=f"e2e_{test_file.stem}",
             ci_stage="test",
             description=f"{test_file.stem}: init",
             outputs=run_dir / ".litani_cache_dir",
@@ -129,7 +129,7 @@ def add_e2e_tests(litani, test_dir, counter, output_dir, fast):
                 --litani {litani}
                 --run-dir {run_dir}
                 --operation add-jobs"""),
-            pipeline=f"End-to-end: {test_file.stem}",
+            pipeline=f"e2e_{test_file.stem}",
             ci_stage="test",
             description=f"{test_file.stem}: add jobs",
             inputs=run_dir / ".litani_cache_dir",
@@ -149,7 +149,7 @@ def add_e2e_tests(litani, test_dir, counter, output_dir, fast):
                     --litani {litani}
                     --run-dir {run_dir}
                     --operation transform-jobs"""),
-                pipeline=f"End-to-end: {test_file.stem}",
+                pipeline=f"e2e_{test_file.stem}",
                 ci_stage="test",
                 description=f"{test_file.stem}: transform jobs",
                 inputs=add_jobs_output,
@@ -164,7 +164,7 @@ def add_e2e_tests(litani, test_dir, counter, output_dir, fast):
                 --litani {litani}
                 --run-dir {run_dir}
                 --operation run-build"""),
-            pipeline=f"End-to-end: {test_file.stem}",
+            pipeline=f"e2e_{test_file.stem}",
             ci_stage="test",
             description=f"{test_file.stem}: run build",
             inputs=run_build_input,
@@ -180,7 +180,7 @@ def add_e2e_tests(litani, test_dir, counter, output_dir, fast):
                 --litani {litani}
                 --run-dir {run_dir}
                 --operation check-run"""),
-            pipeline=f"End-to-end: {test_file.stem}",
+            pipeline=f"e2e_{test_file.stem}",
             ci_stage="report",
             description=f"{test_file.stem}: check run",
             inputs=f"{run_dir}/output/run.json",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Litani Test Suite gets stuck sometimes on some specific proofs and
gets timed out. With this commit we can access those reports as
artifacts and dive into the issue instead of trying to recreate the
errors again locally.

[Example Run](https://github.com/awslabs/aws-build-accumulator/actions/runs/2041065375)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
