### PR TITLE
Add concurrency-safe HTML report directory API

### DIFF
--- a/doc/src/man/litani-acquire-html-dir.scdoc
+++ b/doc/src/man/litani-acquire-html-dir.scdoc
@@ -1,0 +1,72 @@
+litani-acquire-html-dir(1) "" "Litani Build System"
+
+; Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+; Licensed under the Apache License, Version 2.0 (the "License").
+; You may not use this file except in compliance with the License.
+; A copy of the License is located at
+
+;     http://www.apache.org/licenses/LICENSE-2.0
+
+; or in the "license" file accompanying this file. This file is distributed
+; on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+; express or implied. See the License for the specific language governing
+; permissions and limitations under the License.
+
+
+# NAME
+
+litani acquire-html-dir - Print the path to a locked HTML report directory
+
+
+# SYNOPSIS
+
+*litani acquire-html-dir*
+	*-t*/*--timeout* _N_
+
+
+# DESCRIPTION
+
+This program attempts to acquire a lock on the most recently-written Litani HTML
+report, and prints the path to that locked directory.
+
+This command should be used to get a path to a HTML report that is guaranteed to
+not be deleted or modified by other processes that also use this locking API.
+If you instead want the path to a HTML report directory that Litani will
+continuously refresh with updated progress, use *litani-print-html-dir(1)*.
+
+If this command returns successfully, subsequent invocations of this command
+will either hang, time out, or print the path to a different report directory.
+That continues until *litani-release-html-dir(1)* is run. This program should
+thus be used by cooperating processes that wish to have exclusive access to a
+HTML report. Well-behaved processes should only modify HTML report directories
+after this command has successfully returned, and should run
+*litani-release-html-dir(1)* after finishing their modifications.
+
+
+# MULTIPROCESS SAFETY
+
+It is safe to run this program concurrently with any other Litani command.
+
+
+# OPTIONS
+
+*--t*/*--timeout* _N_
+	Terminate with a return code of 1 if unable to acquire an HTML report
+	directory after _N_ seconds. If _N_ is *0*, this program will continue trying
+	to acquire a directory forever. It is recommended to set a non-zero timeout
+	because this program might livelock if, for example, a concurrent invocation
+	of *litani run-build* crashes in the middle of writing a report directory.
+
+
+# OUTPUT & RETURN CODE
+
+This program prints out the path to an HTML report directory and returns 0 if it
+was able to acquire a lock on that directory. This program returns 2 if there
+was a command line error. Otherwise, this program prints nothing and returns 1.
+
+
+# SEE ALSO
+
+- *litani-print-html-dir(1)*
+- *litani-release-html-dir(1)*

--- a/doc/src/man/litani-print-html-dir.scdoc
+++ b/doc/src/man/litani-print-html-dir.scdoc
@@ -1,0 +1,63 @@
+litani-print-html-dir(1) "" "Litani Build System"
+
+; Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+; Licensed under the Apache License, Version 2.0 (the "License").
+; You may not use this file except in compliance with the License.
+; A copy of the License is located at
+
+;     http://www.apache.org/licenses/LICENSE-2.0
+
+; or in the "license" file accompanying this file. This file is distributed
+; on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+; express or implied. See the License for the specific language governing
+; permissions and limitations under the License.
+
+
+# NAME
+
+litani print-html-dir - Print the path to a continually-updated report directory
+
+
+# SYNOPSIS
+
+*litani print-html-dir*
+
+
+# DESCRIPTION
+
+This program prints the path to a Litani HTML report directory that will be
+continuously updated while *litani-run-build(1)* is concurrently running.
+
+This command is intended to be used by clients who wish to read the most
+up-to-date report directory without modifying it. *litani-run-build(1)* will
+update the report directory periodically while it is running. Thus, this command
+can be used to print a path to be viewed in a web browser, for example.
+
+*litani-run-build(1)* refreshes the report directory atomically, that is, the
+entire HTML report (including the pipeline subpages) are updated all at once.
+Clients can continue to read the new report data using the same path that this
+command originally printed. This is implemented through atomically moving a
+symbolic link from the old to the new report directories.
+
+Clients should _not_ resolve the path that this command prints out before
+accessing it. This command prints out the path to a symbolic link, and access to
+report data should be through the symbolic link only. In particular,
+*litani-run-build(1)* will occasionally garbage-collect old HTML report
+directories, but the path that this command prints out will always point to a
+current (not garbage-collected) report.
+
+
+# MULTIPROCESS SAFETY
+
+It is safe to run this program concurrently with any other Litani command.
+
+
+# OUTPUT & RETURN CODE
+
+This program prints out the path to an HTML report directory and returns 0.
+
+
+# SEE ALSO
+
+- *litani-acquire-html-dir(1)*

--- a/doc/src/man/litani-release-html-dir.scdoc
+++ b/doc/src/man/litani-release-html-dir.scdoc
@@ -1,0 +1,68 @@
+litani-release-html-dir(1) "" "Litani Build System"
+
+; Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+; Licensed under the Apache License, Version 2.0 (the "License").
+; You may not use this file except in compliance with the License.
+; A copy of the License is located at
+
+;     http://www.apache.org/licenses/LICENSE-2.0
+
+; or in the "license" file accompanying this file. This file is distributed
+; on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+; express or implied. See the License for the specific language governing
+; permissions and limitations under the License.
+
+
+# NAME
+
+litani release-html-dir - Unlock a previously-locked HTML report directory
+
+
+# SYNOPSIS
+
+*litani release-html-dir*
+	*-d*/*--dir* _D_
+
+
+# DESCRIPTION
+
+This program releases a lock on a Litani HTML report directory that had
+previously been locked through an invocation of *litani-acquire-html-dir(1)*.
+This allows other processes to attempt to acquire the directory.
+
+After this command returns, it becomes possible for a single subsequent (or
+currently-running) invocation of *litani-acquire-html-dir(1)* to terminate
+successfully.
+
+It is an error to run this command if you have not previously acquired the
+specified report directory using *litani-acquire-html-dir(1)*. Litani does not
+check that the locking API is being used correctly, so doing this may cause a
+race where more than one process can modify a single report directory
+concurrently.
+
+It is important to release a directory after acquiring it and completing any
+modifications, so that a concurrent run of *litani-run-build(1)* can acquire
+stale HTML report directories for garbage collection.
+
+
+# MULTIPROCESS SAFETY
+
+It is safe to run this program concurrently with any other Litani command.
+
+
+# OPTIONS
+
+*-d*/*--dir* _D_
+	The path to a Litani HTML report directory that had previously been printed
+	out from an invocation of *litani-acquire-html-dir(1)*.
+
+
+# RETURN CODE
+
+This program returns 0.
+
+
+# SEE ALSO
+
+- *litani-acquire-html-dir(1)*

--- a/doc/src/man/litani.scdoc
+++ b/doc/src/man/litani.scdoc
@@ -76,6 +76,15 @@ The following is a synopsis of Litani's subcommands:
 	Print a JSON representation of the run so far to stdout both while the
 	build is running as well as after it has completed.
 
+*litani print-html-dir*
+	Print the path to a continually-updated HTML report directory
+
+*litani acquire-html-dir*
+	Print the path to a locked HTML report directory
+
+*litani release-html-dir*
+	Unlock a previously-locked HTML report directory
+
 *litani graph*
 	Print the dependency graph of the build in Graphviz format, ready to
 	be rendered into an image using *dot(1)*.

--- a/lib/capabilities.py
+++ b/lib/capabilities.py
@@ -28,6 +28,9 @@ _CAPABILITIES = {
     "parallelism_metric": "Run contains process parallelism measurements",
     "phony_outputs": "The --phony-outputs flag is supported",
     "dump_run": "The dump-run command is supported",
+    "acquire_html_dir": "The acquire-html-dir command is supported",
+    "release_html_dir": "The release-html-dir command is supported",
+    "print_html_dir": "The print-html-dir command is supported",
 }
 
 

--- a/lib/litani_report.py
+++ b/lib/litani_report.py
@@ -12,6 +12,7 @@
 # permissions and limitations under the License.
 
 
+import asyncio
 import dataclasses
 import datetime
 import enum
@@ -383,6 +384,32 @@ class ReportRenderer:
 
         litani.unlink_expired()
 
+
+
+async def release_html_dir(args):
+    lockable_dir = lib.litani.LockableDirectory(args.dir)
+    lockable_dir.release()
+
+
+async def acquire_html_dir(args):
+    remaining = args.timeout
+    while True:
+        html_dir = lib.litani.get_report_dir().resolve()
+        lockable_dir = lib.litani.LockableDirectory(html_dir)
+        if lockable_dir.acquire():
+            print(html_dir)
+            sys.exit(0)
+        remaining -= 1
+        if remaining == 0:
+            sys.exit(1)
+        await asyncio.sleep(1)
+
+
+async def print_html_dir(_):
+    html_dir = lib.litani.get_report_dir()
+    if not html_dir.exists():
+        sys.exit(1)
+    print(html_dir)
 
 
 def get_run(cache_dir):

--- a/lib/litani_report.py
+++ b/lib/litani_report.py
@@ -616,8 +616,11 @@ def render(run, report_dir, pipeline_depgraph_renderer):
 
     locked_dir.release()
 
-    if old_report_dir_path.exists():
+    try:
         old_report_dir.expire()
+    except FileNotFoundError:
+        pass
+
     litani.unlink_expired()
 
 

--- a/lib/litani_report.py
+++ b/lib/litani_report.py
@@ -297,107 +297,92 @@ class StatsGroupRenderer:
 
 
 
-def render(run, report_dir, pipeline_depgraph_renderer):
-    temporary_report_dir = litani.get_report_data_dir() / str(uuid.uuid4())
-    temporary_report_dir.mkdir(parents=True)
-    old_report_dir_path = litani.get_report_dir().resolve()
-    old_report_dir = litani.ExpireableDirectory(old_report_dir_path)
+@dataclasses.dataclass
+class ReportRenderer:
+    report_dir: pathlib.Path
+    pipeline_depgraph_renderer: PipelineDepgraphRenderer
 
-    artifact_dir = temporary_report_dir / "artifacts"
-    shutil.copytree(litani.get_artifacts_dir(), artifact_dir)
 
-    template_dir = pathlib.Path(__file__).parent.parent / "templates"
-    env = jinja2.Environment(
-        loader=jinja2.FileSystemLoader(str(template_dir)),
-        autoescape=jinja2.select_autoescape(
-            enabled_extensions=('html'),
-            default_for_string=True))
+    def __call__(self, run):
+        temporary_report_dir = litani.get_report_data_dir() / str(uuid.uuid4())
+        temporary_report_dir.mkdir(parents=True)
+        old_report_dir_path = litani.get_report_dir().resolve()
+        old_report_dir = litani.ExpireableDirectory(old_report_dir_path)
 
-    render_artifact_indexes(artifact_dir, env)
+        artifact_dir = temporary_report_dir / "artifacts"
+        shutil.copytree(litani.get_artifacts_dir(), artifact_dir)
 
-    gnuplot = Gnuplot()
-    svgs = get_dashboard_svgs(run, env, gnuplot)
+        template_dir = pathlib.Path(__file__).parent.parent / "templates"
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(str(template_dir)),
+            autoescape=jinja2.select_autoescape(
+                enabled_extensions=('html'),
+                default_for_string=True))
 
-    litani_report_archive_path = os.getenv("LITANI_REPORT_ARCHIVE_PATH")
+        render_artifact_indexes(artifact_dir, env)
 
-    with litani.atomic_write(temporary_report_dir / litani.RUN_FILE) as handle:
-        print(json.dumps(run, indent=2), file=handle)
+        gnuplot = Gnuplot()
+        svgs = get_dashboard_svgs(run, env, gnuplot)
 
-    front_page_outputs = {}
-    pipe_templ = env.get_template("pipeline.jinja.html")
-    for pipe in run["pipelines"]:
-        pipeline_depgraph_renderer.render(
-            render_root=temporary_report_dir,
-            pipe_url=pathlib.Path(pipe["url"]), pipe=pipe)
-        for stage in pipe["ci_stages"]:
-            for job in stage["jobs"]:
-                if JobOutcomeTableRenderer.should_render(job):
-                    JobOutcomeTableRenderer.render(
-                        temporary_report_dir / pipe["url"], env, job)
-                if MemoryTraceRenderer.should_render(job):
-                    MemoryTraceRenderer.render(
-                        temporary_report_dir / pipe["url"], env, job, gnuplot)
+        litani_report_archive_path = os.getenv("LITANI_REPORT_ARCHIVE_PATH")
 
-                tags = job["wrapper_arguments"]["tags"]
-                description = job["wrapper_arguments"]["description"]
-                if tags and "front-page-text" in tags:
-                    if "stdout" in job and job["stdout"]:
-                        front_page_outputs[description] = job
-
-        pipe_page = pipe_templ.render(run=run, pipe=pipe)
         with litani.atomic_write(
-                temporary_report_dir / pipe["url"] / "index.html") as handle:
-            print(pipe_page, file=handle)
+                temporary_report_dir / litani.RUN_FILE) as handle:
+            print(json.dumps(run, indent=2), file=handle)
 
-    dash_templ = env.get_template("dashboard.jinja.html")
-    page = dash_templ.render(
-        run=run, svgs=svgs,
-        litani_version=litani.VERSION,
-        litani_report_archive_path=litani_report_archive_path,
-        summary=get_summary(run), front_page_outputs=front_page_outputs)
+        front_page_outputs = {}
+        pipe_templ = env.get_template("pipeline.jinja.html")
+        for pipe in run["pipelines"]:
+            self.pipeline_depgraph_renderer.render(
+                render_root=temporary_report_dir,
+                pipe_url=pathlib.Path(pipe["url"]), pipe=pipe)
+            for stage in pipe["ci_stages"]:
+                for job in stage["jobs"]:
+                    if JobOutcomeTableRenderer.should_render(job):
+                        JobOutcomeTableRenderer.render(
+                            temporary_report_dir / pipe["url"], env, job)
+                    if MemoryTraceRenderer.should_render(job):
+                        MemoryTraceRenderer.render(
+                            temporary_report_dir / pipe["url"], env, job,
+                            gnuplot)
 
-    with litani.atomic_write(temporary_report_dir / "index.html") as handle:
-        print(page, file=handle)
+                    tags = job["wrapper_arguments"]["tags"]
+                    description = job["wrapper_arguments"]["description"]
+                    if tags and "front-page-text" in tags:
+                        if "stdout" in job and job["stdout"]:
+                            front_page_outputs[description] = job
 
-    # The sequence is:
-    #
-    # Initially:
-    # |\_ report_data_dir
-    # |    |\_ 1234-abcd [report data that has just been written]
-    # |    \__ 5678-olde
-    # \__ html  -symlink->  report_data_dir/5678-olde
-    #
-    # 1. 1234-abcd gets locked
-    #
-    # 2. report_data_dir
-    #    |- 1234-abcd
-    #    |- 5678-olde
-    #    html  -symlink->  report_data_dir/5678-olde
-    #    html.987-xzy  -symlink->  1234-abcd
-    #
-    # 3. report_data_dir
-    #    |- 1234-abcd
-    #    |- 5678-olde
-    #    html  -symlink->  1234-abcd
-    #
-    # 4. 1234-abcd gets unlocked
-    #
-    # 5. 5678-olde gets marked as expired.
+            pipe_page = pipe_templ.render(run=run, pipe=pipe)
+            with litani.atomic_write(
+                    temporary_report_dir / pipe["url"] / "index.html") as handle:
+                print(pipe_page, file=handle)
 
-    locked_dir = litani.LockableDirectory(temporary_report_dir)
+        dash_templ = env.get_template("dashboard.jinja.html")
+        page = dash_templ.render(
+            run=run, svgs=svgs,
+            litani_version=litani.VERSION,
+            litani_report_archive_path=litani_report_archive_path,
+            summary=get_summary(run), front_page_outputs=front_page_outputs)
 
-    temp_symlink_dir = report_dir.with_name(report_dir.name + str(uuid.uuid4()))
-    os.symlink(temporary_report_dir, temp_symlink_dir)
-    os.rename(temp_symlink_dir, report_dir)
+        with litani.atomic_write(temporary_report_dir / "index.html") as handle:
+            print(page, file=handle)
 
-    locked_dir.release()
+        locked_dir = litani.LockableDirectory(temporary_report_dir)
 
-    try:
-        old_report_dir.expire()
-    except FileNotFoundError:
-        pass
+        temp_symlink_dir = self.report_dir.with_name(
+            self.report_dir.name + str(uuid.uuid4()))
+        os.symlink(temporary_report_dir, temp_symlink_dir)
+        os.rename(temp_symlink_dir, self.report_dir)
 
-    litani.unlink_expired()
+        locked_dir.release()
+
+        try:
+            old_report_dir.expire()
+        except FileNotFoundError:
+            pass
+
+        litani.unlink_expired()
+
 
 
 def get_run(cache_dir):

--- a/litani
+++ b/litani
@@ -209,6 +209,38 @@ def get_args():
         flags = arg.pop("flags")
         transform_jobs_pars.add_argument(*flags, **arg)
 
+    release_html_dir_pars = subs.add_parser("release-html-dir",
+        help="Unlock a previously-locked HTML report directory")
+    release_html_dir_pars.set_defaults(func=lib.litani_report.release_html_dir)
+    for arg in [{
+            "flags": ["-d", "--dir"],
+            "help": "the locked HTML report directory to unlock",
+            "required": True,
+            "type": pathlib.Path,
+            "metavar": "D",
+    }]:
+        flags = arg.pop("flags")
+        release_html_dir_pars.add_argument(*flags, **arg)
+
+    acquire_html_dir_pars = subs.add_parser("acquire-html-dir",
+        help="Print the path to a locked HTML report directory")
+    acquire_html_dir_pars.set_defaults(func=lib.litani_report.acquire_html_dir)
+    for arg in [{
+            "flags": ["-t", "--timeout"],
+            "help": (
+                "how many seconds to wait before giving up "
+                "(0 means forever)"),
+            "required": True,
+            "type": non_negative_int,
+            "metavar": "N",
+    }]:
+        flags = arg.pop("flags")
+        acquire_html_dir_pars.add_argument(*flags, **arg)
+
+    print_html_dir_pars = subs.add_parser("print-html-dir",
+        help="Print out the path to the HTML report directory")
+    print_html_dir_pars.set_defaults(func=lib.litani_report.print_html_dir)
+
     caps_pars = subs.add_parser("print-capabilities",
         help="Print out Litani's capabilities in a list")
     caps_pars.set_defaults(func=lib.capabilities.dump)

--- a/litani
+++ b/litani
@@ -300,7 +300,7 @@ def get_args():
 
 
 def continuous_render_report(
-    cache_dir, report_dir, killer, out_file, pipeline_degraph_renderer):
+    cache_dir, killer, out_file, render):
     try:
         while True:
             run = litani_report.get_run_data(cache_dir)
@@ -310,7 +310,7 @@ def continuous_render_report(
             if out_file is not None:
                 with litani.atomic_write(out_file) as handle:
                     print(json.dumps(run, indent=2), file=handle)
-            litani_report.render(run, report_dir, pipeline_degraph_renderer)
+            render(run)
             if killer.is_set():
                 break
             time.sleep(2)
@@ -606,17 +606,18 @@ async def run_build(args):
         for build in builds:
             logging.debug(build)
             ninja.build(**build)
-    report_dir = litani.get_report_dir()
     run = litani_report.get_run_data(cache_dir)
     lib.validation.validate_run(run)
-    pipeline_degraph_renderer = litani_report.PipelineDepgraphRenderer(
+    report_dir = lib.litani.get_report_dir()
+    pipeline_depgraph_renderer = litani_report.PipelineDepgraphRenderer(
         should_render=not args.no_pipeline_dep_graph)
-    litani_report.render(run, report_dir, pipeline_degraph_renderer)
+    render = litani_report.ReportRenderer(
+        report_dir, pipeline_depgraph_renderer)
+    render(run)
     killer = threading.Event()
     render_thread = threading.Thread(
         group=None, target=continuous_render_report,
-        args=(cache_dir, report_dir, killer, args.out_file,
-        pipeline_degraph_renderer))
+        args=(cache_dir, killer, args.out_file, render))
     render_thread.start()
 
     runner = lib.ninja.Runner(
@@ -654,7 +655,7 @@ async def run_build(args):
     render_thread.join()
     run = litani_report.get_run_data(cache_dir)
     lib.validation.validate_run(run)
-    litani_report.render(run, report_dir, pipeline_degraph_renderer)
+    render(run)
 
     with litani.atomic_write(cache_dir / litani.RUN_FILE) as handle:
         print(json.dumps(run, indent=2), file=handle)


### PR DESCRIPTION
This feature adds 3 new commands that allow Litani clients to access the HTML report, either for continuous viewing or modification.

- `litani print-html-dir` prints the path to a HTML report directory that will be continuously updated with new progress while `litani run-build` runs. This is the command for local users to use for viewing the HTML report in a browser, for example.
- `litani acquire-html-dir` prints the path to an exclusively-locked HTML report directory. After this command terminates, the printed-out directory will not be deleted or modified until `litani release-html-dir` is subsequently called. This is the command to use when you require prolonged exclusive access to HTML data, for example while doing a file transfer.
- `litani release-html-dir` releases the lock on a previously-acquired HTML report directory. This allows other processes to attempt to lock the directory, and also allows *litani run-build* to acquire the directory for garbage collection.

This feature gives users a safe way to get the path to a HTML report directory that meets their usage requirements, and without relying on internal Litani implementation details.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
