### PR TITLE
Fix get-jobs test check

### DIFF
--- a/test/e2e/run
+++ b/test/e2e/run
@@ -112,7 +112,8 @@ def get_jobs(litani, run_dir, mod):
     cmd.extend(configure_args(*args.get("args", []), **args.get("kwargs", {})))
     jobs = subprocess.check_output(cmd)
 
-    mod.check_get_jobs(jobs)
+    if not mod.check_get_jobs(jobs):
+        sys.exit(1)
 
     for job in mod.get_post_check_jobs():
         run_litani(

--- a/test/e2e/tests/get_jobs_single_job.py
+++ b/test/e2e/tests/get_jobs_single_job.py
@@ -19,7 +19,7 @@ SLOW = False
 
 EXPECTED_JOB = {
     "command": "echo foo",
-    "ci-stage": "build",
+    "ci_stage": "build",
     "pipeline": "foo",
 }
 


### PR DESCRIPTION
This commit makes the end-to-end tests for get-jobs actually check the
result of the test, and fixes a test that was failing silently.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
