### PR TITLE
Accept lists of input/output files embedded in JSON files

### DIFF
--- a/doc/src/man/litani-add-job.scdoc
+++ b/doc/src/man/litani-add-job.scdoc
@@ -71,6 +71,9 @@ configure times.
 
 *--inputs* _F_ [_F_ ...]
 	A list of inputs that this job depends on. Litani interprets each _F_ as a file:
+	- If _F_ starts with @, then treat the remainder of the file name as JSON
+	  file containing a list of files, which in turn are to be handled as
+	  specified in the following items.
 	- If every _F_ exists and has an older timestamp than all of this job's
 	  outputs, then Litani will not run this job.
 	- If some of the _F_ are newer than any of this job's outputs, then those
@@ -81,7 +84,8 @@ configure times.
 	  out-of-date files, then the build will fail.
 
 *--outputs* _F_ [_F_ ...]
-	A list of outputs that this job emits. Litani interprets each _F_ as a file,
+	A list of outputs that this job emits. Litani interprets each _F_ as a file
+	(or a JSON file if prefixed with @, as described for *--inputs* above),
 	and expects that the command will write a file with that name upon completion.
 	If a job _J_ has _F_ as an output, but does not actually write a file called
 	_F_, then _J_ will run unconditionally because _F_ will always be considered

--- a/lib/graph.py
+++ b/lib/graph.py
@@ -177,12 +177,12 @@ class SinglePipelineGraph:
                 args["command"])
             self.nodes.add(cmd_node)
 
-            for inputt in args.get("inputs") or []:
+            for inputt in lib.litani.expand_args(args.get("inputs")):
                 in_node = lib.graph.DependencyNode(inputt)
                 self.nodes.add(in_node)
                 self.edges.add(lib.graph.Edge(src=in_node, dst=cmd_node))
 
-            for output in args.get("outputs") or []:
+            for output in lib.litani.expand_args(args.get("outputs")):
                 out_node = lib.graph.DependencyNode(output)
                 self.nodes.add(out_node)
                 self.edges.add(lib.graph.Edge(src=cmd_node, dst=out_node))
@@ -265,12 +265,12 @@ class Graph:
                 args["pipeline_name"], args["description"], args["command"])
             nodes.add(cmd_node)
             if args["outputs"]:
-                for output in args["outputs"]:
+                for output in lib.litani.expand_args(args["outputs"]):
                     out_node = DependencyNode(output)
                     nodes.add(out_node)
                     edges.add(Edge(src=cmd_node, dst=out_node))
             if args["inputs"]:
-                for inputt in args["inputs"]:
+                for inputt in lib.litani.expand_args(args["inputs"]):
                     in_node = DependencyNode(inputt)
                     nodes.add(in_node)
                     edges.add(Edge(src=in_node, dst=cmd_node))

--- a/lib/litani.py
+++ b/lib/litani.py
@@ -269,3 +269,21 @@ def unlink_expired():
             # No need to release lock after deletion
         else:
             lock_dir.release()
+
+
+def expand_args(files):
+    """Produce a list of files by expanding any "@"-prefixed file names to their
+    JSON-list contents.
+    """
+    if not files:
+        return []
+
+    result = []
+    for f in files:
+        if f.startswith("@"):
+            with open(f[1:]) as json_file:
+                result.extend(json.load(json_file))
+        else:
+            result.append(f)
+
+    return result

--- a/litani
+++ b/litani
@@ -444,8 +444,8 @@ def fill_out_ninja(cache, rules, builds, pools):
         pools[name] = depth
 
     for entry in cache["jobs"]:
-        outs = entry["outputs"] or []
-        ins = entry["inputs"] or []
+        outs = lib.litani.expand_args(entry["outputs"])
+        ins = lib.litani.expand_args(entry["inputs"])
 
         if "description" in entry:
             description = entry["description"]


### PR DESCRIPTION
If an argument to --inputs or --outputs starts with "@" the remaining
argument is now treated as the name of a JSON file to be read. This
should help work around the OS limit on the maximum number of
command-line arguments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
