### PR TITLE
Make run-build return 10 to signal pipe failure

### DIFF
--- a/doc/src/man/litani-run-build.scdoc
+++ b/doc/src/man/litani-run-build.scdoc
@@ -66,7 +66,10 @@ parallel.
 
 # RETURN CODE
 
-Unless there was a crash, this program should return _0_ upon exit
-unless the *--fail-on-pipeline-failure* flag was supplied. In that case,
-this program will return _0_ if all pipelines were successful and _1_
-otherwise.
+This program will return _1_ if it terminates abnormally. On normal
+termination:
+
+- If the *--fail-on-pipeline-failure* flag was passed, this program will
+  return _0_ if all pipelines were successful and _10_ otherwise.
+- Otherwise, this program will always return _0_ upon normal
+  termination, regardless of the pipelines' success or failure.

--- a/litani
+++ b/litani
@@ -702,7 +702,7 @@ async def run_build(args):
               f"file://{run_info['latest_symlink']}/html/index.html")
 
     if args.fail_on_pipeline_failure:
-        sys.exit(0 if runner.was_successful() else 1)
+        sys.exit(0 if runner.was_successful() else 10)
 
     sys.exit(0)
 


### PR DESCRIPTION
Prior to this commit, the return code of litani run-build with the
--fail-on-pipeline-failure flag did not distinguish between a litani
crash and a failure of one or more pipelines. This commit makes
pipeline failure result in a unique return code of 10.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
