### PR TITLE
Summarize build results by printing a JSON object

### DIFF
--- a/doc/src/man/litani-run-build.scdoc
+++ b/doc/src/man/litani-run-build.scdoc
@@ -14,6 +14,7 @@ litani run-build - Start a Litani run
 	\[*-n*/*--dry-run*]
 	\[*-j*/*--parallel* _N_]
 	\[*-o*/*--out-file* _F_]
+	\[*--summarize-results*]
 	\[*--fail-on-pipeline-failure*]
 	\[*--no-pipeline-dep-graph*]
 	\[*-p*/*--pipelines* _P_ [_P_ ...]]
@@ -46,6 +47,11 @@ parallel.
 
 *-o* _F_, *--out-file* _F_
 	Periodically write the _run.json_ file to _F_.
+
+*--summarize-results*
+	Summarize build results by printing a JSON object. A user will be able
+	to get a breakdown of statuses across pipelines as well as a breakdown
+	of the status of each pipeline.
 
 *--fail-on-pipeline-failure*
 	Return _0_ only if all pipelines were successful. See *RETURN CODE*

--- a/lib/post_build.py
+++ b/lib/post_build.py
@@ -1,0 +1,34 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import json
+
+
+def get_summary(run_dict):
+    # The list of possible statuses can be viewed in the man page for run.json
+    status_summary_map = {}
+    pipeline_status_map = {}
+    for pipeline in run_dict["pipelines"]:
+        status_name_pretty = pipeline["status"].title().replace("_", " ")
+        try:
+            status_summary_map[status_name_pretty] += 1
+        except KeyError:
+            status_summary_map[status_name_pretty] = 1
+        pipeline_status_map[pipeline["name"]] = status_name_pretty
+    return json.dumps({
+        "Breakdown of statuses across pipelines": status_summary_map,
+        "Breakdown of status per pipeline": pipeline_status_map}, indent=2)
+
+
+def summarize_results(run_dict):
+    print(get_summary(run_dict))

--- a/litani
+++ b/litani
@@ -39,6 +39,7 @@ import lib.jobs
 import lib.ninja
 import lib.output_artifact
 import lib.pid_file
+import lib.post_build
 import lib.process
 import lib.run_printer
 import lib.validation
@@ -267,6 +268,10 @@ def get_args():
             "flags": ["-o", "--out-file"],
             "metavar": "F",
             "help": "periodically write JSON representation of the run"
+    }, {
+            "flags": ["--summarize-results"],
+            "action": "store_true",
+            "help": "prints a JSON object summarizing the results of the build"
     }, {
             "flags": ["--fail-on-pipeline-failure"],
             "action": "store_true",
@@ -701,6 +706,8 @@ async def run_build(args):
         print("Report was rendered at "
               f"file://{run_info['latest_symlink']}/html/index.html")
 
+    if args.summarize_results:
+        lib.post_build.summarize_results(run)
     if args.fail_on_pipeline_failure:
         sys.exit(0 if runner.was_successful() else 10)
 

--- a/test/unit/post_build.py
+++ b/test/unit/post_build.py
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+import json
+import pathlib
+import unittest
+import unittest.mock
+
+import lib.post_build
+
+
+class TestSummarizeResults(unittest.TestCase):
+    def setUp(self):
+        self.run_file = pathlib.Path().cwd() / "test/unit/sample_run.json"
+
+
+    def test_get_summary(self):
+        expected = json.dumps({
+            "Breakdown of statuses across pipelines": {
+                "Fail": 1,
+                "Success": 1
+            },
+            "Breakdown of status per pipeline": {
+                "pipe-will-fail": "Fail",
+                "pipe-will-succeed": "Success"
+            }
+        }, indent=2)
+        with open(self.run_file) as fp:
+            contents = json.load(fp)
+            actual = lib.post_build.get_summary(contents)
+            self.assertEqual(expected, actual)

--- a/test/unit/sample_run.json
+++ b/test/unit/sample_run.json
@@ -1,0 +1,187 @@
+{
+  "aux": {},
+  "project": "example-build",
+  "version": "1.26.0-rc",
+  "version_major": 1,
+  "version_minor": 26,
+  "version_patch": 0,
+  "release_candidate": true,
+  "run_id": "b018ce5a-e34c-45ee-80bc-209c60622e1f",
+  "stages": [
+    "build",
+    "test",
+    "report"
+  ],
+  "start_time": "2022-05-24T02:48:34Z",
+  "status": "fail",
+  "pools": {},
+  "parallelism": {
+    "trace": [
+      {
+        "running": 1,
+        "finished": 1,
+        "total": 1,
+        "time": "2022-05-24T02:51:28.057125Z"
+      }
+    ],
+    "max_parallelism": 1,
+    "n_proc": 12
+  },
+  "latest_symlink": "/var/folders/bd/w7pff05n5k35735rjvph7dkh0000gs/T/litani/runs/latest",
+  "end_time": "2022-05-24T02:51:28Z",
+  "pipelines": [
+    {
+      "name": "pipe-will-fail",
+      "ci_stages": [
+        {
+          "jobs": [],
+          "progress": 0,
+          "complete": true,
+          "status": "success",
+          "url": "artifacts/pipe-will-fail/build",
+          "name": "build"
+        },
+        {
+          "jobs": [],
+          "progress": 0,
+          "complete": true,
+          "status": "success",
+          "url": "artifacts/pipe-will-fail/test",
+          "name": "test"
+        },
+        {
+          "jobs": [
+            {
+              "wrapper_arguments": {
+                "subcommand": "exec",
+                "verbose": false,
+                "very_verbose": false,
+                "inputs": null,
+                "command": "/usr/bin/false",
+                "outputs": null,
+                "pipeline_name": "pipe-will-fail",
+                "ci_stage": "report",
+                "cwd": null,
+                "timeout": null,
+                "timeout_ok": false,
+                "timeout_ignore": false,
+                "ignore_returns": null,
+                "ok_returns": null,
+                "outcome_table": null,
+                "interleave_stdout_stderr": false,
+                "stdout_file": null,
+                "stderr_file": null,
+                "pool": null,
+                "description": null,
+                "profile_memory": false,
+                "profile_memory_interval": 10,
+                "phony_outputs": null,
+                "tags": null,
+                "status_file": "/var/folders/bd/w7pff05n5k35735rjvph7dkh0000gs/T/litani/runs/b018ce5a-e34c-45ee-80bc-209c60622e1f/status/0f65a89f-d82a-4a37-8ac6-30172cb8de8b.json",
+                "job_id": "0f65a89f-d82a-4a37-8ac6-30172cb8de8b"
+              },
+              "complete": true,
+              "start_time": "2022-05-24T02:51:28Z",
+              "timeout_reached": false,
+              "command_return_code": 1,
+              "memory_trace": {},
+              "loaded_outcome_dict": null,
+              "outcome": "fail",
+              "wrapper_return_code": 1,
+              "stdout": [],
+              "stderr": [],
+              "end_time": "2022-05-24T02:51:28Z",
+              "duration_str": "00s",
+              "duration": 0
+            }
+          ],
+          "progress": 100,
+          "complete": true,
+          "status": "fail",
+          "url": "artifacts/pipe-will-fail/report",
+          "name": "report"
+        }
+      ],
+      "url": "pipelines/pipe-will-fail",
+      "status": "fail",
+      "dependencies_url": "dependencies.svg"
+    },
+    {
+      "name": "pipe-will-succeed",
+      "ci_stages": [
+        {
+          "jobs": [],
+          "progress": 0,
+          "complete": true,
+          "status": "success",
+          "url": "artifacts/pipe-will-succeed/build",
+          "name": "build"
+        },
+        {
+          "jobs": [
+            {
+              "wrapper_arguments": {
+                "subcommand": "exec",
+                "verbose": false,
+                "very_verbose": false,
+                "inputs": null,
+                "command": "/usr/bin/true",
+                "outputs": null,
+                "pipeline_name": "pipe-will-succeed",
+                "ci_stage": "test",
+                "cwd": null,
+                "timeout": null,
+                "timeout_ok": false,
+                "timeout_ignore": false,
+                "ignore_returns": null,
+                "ok_returns": null,
+                "outcome_table": null,
+                "interleave_stdout_stderr": false,
+                "stdout_file": null,
+                "stderr_file": null,
+                "pool": null,
+                "description": null,
+                "profile_memory": false,
+                "profile_memory_interval": 10,
+                "phony_outputs": null,
+                "tags": null,
+                "status_file": "/var/folders/bd/w7pff05n5k35735rjvph7dkh0000gs/T/litani/runs/b018ce5a-e34c-45ee-80bc-209c60622e1f/status/f29d81df-0692-4002-ae1f-5068d684b025.json",
+                "job_id": "f29d81df-0692-4002-ae1f-5068d684b025"
+              },
+              "complete": true,
+              "start_time": "2022-05-24T02:49:30Z",
+              "timeout_reached": false,
+              "command_return_code": 0,
+              "memory_trace": {},
+              "loaded_outcome_dict": null,
+              "outcome": "success",
+              "wrapper_return_code": 0,
+              "stdout": [],
+              "stderr": [],
+              "end_time": "2022-05-24T02:49:30Z",
+              "duration_str": "00s",
+              "duration": 0
+            }
+          ],
+          "progress": 100,
+          "complete": true,
+          "status": "success",
+          "url": "artifacts/pipe-will-succeed/test",
+          "name": "test"
+        },
+        {
+          "jobs": [],
+          "progress": 0,
+          "complete": true,
+          "status": "success",
+          "url": "artifacts/pipe-will-succeed/report",
+          "name": "report"
+        }
+      ],
+      "url": "pipelines/pipe-will-succeed",
+      "status": "success",
+      "dependencies_url": "dependencies.svg"
+    }
+  ],
+  "__duration_str": "02m 54s"
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A flag was added to `run-build` that summarizes the results of a build by printing a JSON object.
    
A user will be able to get a breakdown of statuses across pipelines as well as a breakdown of the
status of each pipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
