### PR TITLE
Fix termination of litani run-build

### DIFF
--- a/lib/ninja.py
+++ b/lib/ninja.py
@@ -20,7 +20,6 @@ import math
 import os
 import pathlib
 import re
-import signal
 import subprocess
 import sys
 import threading
@@ -133,50 +132,6 @@ class _OutputAccumulator:
 
 
 
-def _make_pgroup_leader():
-    try:
-        os.setpgid(0, 0)
-    except OSError as err:
-        logging.error(
-            "Failed to create new process group for ninja (errno: %s)",
-            err.errno)
-        sys.exit(1)
-
-
-
-@dataclasses.dataclass
-class _SignalHandler:
-    """
-    Objects of this class are callable. They implement the API of a signal
-    handler, and can thus be passed to Python's signal.signal call.
-    """
-    proc: subprocess.Popen
-    render_killer: threading.Event
-    pgroup: int = None
-
-
-    def __post_init__(self):
-        try:
-            self.pgroup = os.getpgid(self.proc.pid)
-        except ProcessLookupError:
-            logging.error(
-                "Failed to find ninja process group %d", self.proc.pid)
-            sys.exit(1)
-
-
-    def __call__(self, signum, _frame):
-        self.render_killer.set()
-        try:
-            os.killpg(self.pgroup, signum)
-        except OSError as err:
-            logging.error(
-                "Failed to send signal '%s' to ninja process group (errno: %s)",
-                signum, err.errno)
-            sys.exit(1)
-        sys.exit(0)
-
-
-
 @dataclasses.dataclass
 class Runner:
     ninja_file: pathlib.Path
@@ -188,7 +143,7 @@ class Runner:
     proc: subprocess.CompletedProcess = None
     status_parser: _StatusParser = _StatusParser()
     out_acc: _OutputAccumulator = None
-    signal_handler: _SignalHandler = None
+    signal_handler: lib.litani.DescendentTerminator = None
 
 
     def _get_cmd(self):
@@ -212,20 +167,6 @@ class Runner:
         return [str(c) for c in cmd]
 
 
-    def _register_signal_handler(self):
-        sigs = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)
-        fails = []
-        for sig in sigs:
-            try:
-                signal.signal(sig, self.signal_handler)
-            except ValueError:
-                fails.append(str(sig))
-        if fails:
-            logging.error(
-                "Failed to set signal handler for %s", ", ".join(fails))
-            sys.exit(1)
-
-
     def run(self):
         env = {
             **os.environ,
@@ -234,9 +175,9 @@ class Runner:
 
         self.proc = subprocess.Popen(
             self._get_cmd(), env=env, stdout=subprocess.PIPE, text=True,
-            preexec_fn=_make_pgroup_leader)
-        self.signal_handler = _SignalHandler(self.proc, self.render_killer)
-        self._register_signal_handler()
+            preexec_fn=lib.litani.make_pgroup_leader)
+        self.signal_handler = lib.litani.DescendentTerminator(self.proc)
+        lib.litani.register_signal_handler(self.signal_handler)
 
         self.out_acc = _OutputAccumulator(self.proc.stdout, self.status_parser)
         self.out_acc.start()

--- a/lib/ninja.py
+++ b/lib/ninja.py
@@ -143,7 +143,6 @@ class Runner:
     proc: subprocess.CompletedProcess = None
     status_parser: _StatusParser = _StatusParser()
     out_acc: _OutputAccumulator = None
-    signal_handler: lib.litani.DescendentTerminator = None
 
 
     def _get_cmd(self):
@@ -174,10 +173,7 @@ class Runner:
         }
 
         self.proc = subprocess.Popen(
-            self._get_cmd(), env=env, stdout=subprocess.PIPE, text=True,
-            preexec_fn=lib.litani.make_pgroup_leader)
-        self.signal_handler = lib.litani.DescendentTerminator(self.proc)
-        lib.litani.register_signal_handler(self.signal_handler)
+            self._get_cmd(), env=env, stdout=subprocess.PIPE, text=True)
 
         self.out_acc = _OutputAccumulator(self.proc.stdout, self.status_parser)
         self.out_acc.start()

--- a/lib/run_build.py
+++ b/lib/run_build.py
@@ -166,12 +166,12 @@ async def run_build(args):
     killer = threading.Event()
     render_thread = threading.Thread(
         group=None, target=lib.render.continuous_render_report,
-        args=(cache_dir, killer, args.out_file, render))
+        args=(cache_dir, killer, args.out_file, render), daemon=True)
     render_thread.start()
 
     runner = lib.ninja.Runner(
         ninja_file, args.dry_run, args.parallel, args.pipelines,
-        args.ci_stage)
+        args.ci_stage, killer)
 
     lib.pid_file.write()
     sig_handler = lib.run_printer.DumpRunSignalHandler(cache_dir)

--- a/test/bin/write-pid-and-sleep
+++ b/test/bin/write-pid-and-sleep
@@ -15,4 +15,4 @@
 
 mkdir -p pids
 touch "pids/$$"
-sleep 999
+sleep $((999 + $RANDOM % 100))

--- a/test/bin/write-pid-and-sleep
+++ b/test/bin/write-pid-and-sleep
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+mkdir -p pids
+touch "pids/$$"
+sleep 999

--- a/test/e2e/run
+++ b/test/e2e/run
@@ -127,6 +127,11 @@ def set_jobs(litani, run_dir, mod):
         litani, "set-jobs", *args.get("args", []), **args.get("kwargs", {}))
 
 
+def on_run(litani, run_dir, mod):
+    os.chdir(run_dir)
+    mod.on_run()
+
+
 def run_build(litani, run_dir, mod):
     os.chdir(run_dir)
     args = mod.get_run_build_args()
@@ -160,6 +165,7 @@ OPERATIONS = {
     "transform-jobs": transform_jobs,
     "get-jobs": get_jobs,
     "set-jobs": set_jobs,
+    "on-run": on_run,
 }
 
 

--- a/test/e2e/tests/term_basic.py
+++ b/test/e2e/tests/term_basic.py
@@ -1,0 +1,78 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+import logging
+import os
+import pathlib
+import signal
+import sys
+import time
+
+
+def get_init_args():
+    return {
+        "kwargs": {
+            "project": "foo",
+        }
+    }
+
+
+def get_jobs():
+    ret = []
+    test_dir = pathlib.Path(__file__).parent.parent.parent
+    for _ in range(30):
+        ret.append({
+        "kwargs": {
+            "command": test_dir / "bin/write-pid-and-sleep",
+            "ci-stage": "build",
+            "pipeline": "foo",
+        }
+    })
+    return ret
+
+
+def get_run_build_args():
+    return {}
+
+
+def on_run():
+    time.sleep(5)
+    with open(".litani_cache_dir") as handle:
+        cache_dir = pathlib.Path(handle.read().strip())
+    with open(cache_dir / "run-pid") as handle:
+        pid = int(handle.read().strip())
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError:
+        logging.error("Unable to terminate litani run-build")
+        sys.exit(1)
+    time.sleep(5)
+
+    cnt = 0
+    for pid_file in pathlib.Path("pids").iterdir():
+        try:
+            os.kill(int(pid_file.stem), 0)
+        except OSError as exc:
+            pass
+        else:
+            cnt += 1
+
+    if cnt:
+        logging.error(
+            "%d write-pid-and-sleep processes existed after termination", cnt)
+        sys.exit(1)
+
+
+def check_run(run):
+    return True

--- a/test/e2e/tests/term_basic.py
+++ b/test/e2e/tests/term_basic.py
@@ -47,7 +47,7 @@ def get_run_build_args():
 
 
 def on_run():
-    time.sleep(5)
+    time.sleep(20)
     with open(".litani_cache_dir") as handle:
         cache_dir = pathlib.Path(handle.read().strip())
     with open(cache_dir / "run-pid") as handle:

--- a/test/run
+++ b/test/run
@@ -223,6 +223,23 @@ def add_e2e_tests(test_dir, output_dir, fast, queue, litani):
                 cwd=run_dir)
             run_build_dependencies.append(set_jobs_output)
 
+        if test_has_method("on_run"):
+            enqueue_job(
+                queue,
+                command=collapse(f"""
+                    {e2e_test_dir / 'run'}
+                    --test-file {test_file}
+                    --litani {litani}
+                    --run-dir {run_dir}
+                    --operation on-run"""),
+                pipeline=f"e2e_{test_file.stem}",
+                ci_stage="test",
+                description=f"{test_file.stem}: run-build callback",
+                inputs=run_build_dependencies,
+                phony_outputs=str(uuid.uuid4()),
+                cwd=run_dir,
+                timeout=timeout)
+
         enqueue_job(
             queue,
             command=collapse(f"""

--- a/test/run
+++ b/test/run
@@ -348,7 +348,9 @@ async def main():
         tasks.append(task)
     await job_queue.join()
     print("", file=sys.stderr)
-    await run_cmd([litani, "run-build", "--fail-on-pipeline-failure"])
+    await run_cmd([
+        litani, "run-build", "--fail-on-pipeline-failure",
+        "--pipe", "e2e_term_basic"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Pressing Ctrl-C on the keyboard, or otherwise terminating litani
run-build, will now correctly terminate all of its descendants. Prior to
this patchset, the commands of each Litani job would not terminate upon
termination of run-build; instead, they would be reparented to PID 1 and
continue to run.

This patchset makes ninja the leader of a fresh process group. Ninja's
descendants---that is, all subshells, invocations of litani-exec, the
job commands themselves, and any further descendants--- are placed into
this new process group. Upon termination, run-build delivers a
termination signal to the entire process group.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
