### PR TITLE
Update redirect behavior for stages on dashboard page

### DIFF
--- a/templates/dashboard.jinja.html
+++ b/templates/dashboard.jinja.html
@@ -446,13 +446,15 @@ p {
         {% for stage in pipe["ci_stages"] %}
         <div class="pipeline-stage">
 
-          <a class="stage-artifacts-link {{ stage['status'] }}"
-             href="{{ stage['url'] }}/index.html">
-            <div class="stage-bar">
-              <div class="progress" style="width: {{ stage['progress'] }}%">
-              </div><!-- class="progress" -->
-            </div><!-- class="stage-bar" -->
-          </a>
+          {% if stage['jobs'] %}
+            <a class="stage-artifacts-link {{ stage['status'] }}"
+              href="{{ stage['url'] }}/index.html">
+              <div class="stage-bar">
+                <div class="progress" style="width: {{ stage['progress'] }}%">
+                </div><!-- class="progress" -->
+              </div><!-- class="stage-bar" -->
+            </a>
+          {% endif %}{# stage['jobs'] #}
 
         </div><!-- class="pipeline-stage" -->
         {% endfor %}{# stage in pipe["stages"] #}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If a pipeline lacks jobs for a certain stage, then
the corresponding "bar" displayed on the dashboard
page should not be "clickable" and it should not
redirect to an "artifacts page" since no artifacts
will exist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
