### PR TITLE
Modify run-build so artifacts can be uploaded to specified S3 bucket

### DIFF
--- a/doc/src/man/litani-run-build.scdoc
+++ b/doc/src/man/litani-run-build.scdoc
@@ -47,6 +47,14 @@ parallel.
 *-o* _F_, *--out-file* _F_
 	Periodically write the _run.json_ file to _F_.
 
+*--bucket-name* _B_
+	Periodically upload the report directory containing all build artifacts to
+	a Amazon S3 bucket _B_. Both "incremental snapshots" and a final version
+    of the report directory will be uploaded. The location in S3 starts
+    with "BuildArtifacts". It is followed by a subfolder whose name indicates
+    the build's run ID. There are 2 more nested subfolders distinguishing
+    the final report directory from the possibly several incremental ones.
+
 *--fail-on-pipeline-failure*
 	Return _0_ only if all pipelines were successful. See *RETURN CODE*
 	below.

--- a/lib/aws_s3.py
+++ b/lib/aws_s3.py
@@ -1,0 +1,64 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License
+
+import logging
+import os
+import subprocess
+
+from lib import litani, util
+
+
+def _run_aws_s3_sync_command(command, **kwds):
+    if "shell" in kwds and kwds["shell"]:
+        cmd_str = command
+    else:
+        cmd_str = " ".join([str(c) for c in command])
+    logging.info("Command: %s", cmd_str)
+    # pylint: disable=subprocess-run-check
+    proc = subprocess.run(command, **kwds)
+    if proc.returncode:
+        logging.error("Failed to run '%s'", cmd_str)
+    return proc
+
+
+def _to_local_path(*components):
+    return f"{os.path.join(*components)}/"
+
+
+def _to_s3_uri(bucket_name, location):
+    return f"s3://{bucket_name}/{location}"
+
+
+def sync(bucket_name, cache_dir, report_dir_type):
+    html_dir = cache_dir / "html"
+    util.zip_directory(html_dir, report_dir_type)
+
+    local_path = _to_local_path(html_dir)
+    run_id = litani.get_run_id()
+    location = f"{litani.BUILD_ARTIFACTS}/{run_id}/{report_dir_type}"
+    if report_dir_type == litani.INCREMENTAL:
+        snapshot = util.timestamp(format=litani.TIME_FORMAT_FILENAME_FRIENDLY)
+        location = f"{location}/{snapshot}"
+        exclude = str(html_dir / "artifacts" / "*")
+    s3_uri = _to_s3_uri(bucket_name, location)
+    sync_cmd = ["aws", "s3", "sync", local_path, s3_uri, "--only-show-errors"]
+    if report_dir_type == litani.INCREMENTAL:
+        sync_cmd.extend(["--exclude", exclude])
+    attempts = 1 if report_dir_type == litani.INCREMENTAL else 5
+
+    for i in range(attempts):
+        logging.info(
+            "Copying %s to %s - Attempt #%s", local_path, location, str(i+1))
+        proc = _run_aws_s3_sync_command(sync_cmd)
+        if proc.returncode == 0:
+            return

--- a/lib/exec.py
+++ b/lib/exec.py
@@ -96,7 +96,7 @@ async def exec_job(args):
         "wrapper_arguments": args_dict,
         "complete": False,
     }
-    lib.util.timestamp("start_time", out_data)
+    out_data["start_time"] = lib.util.timestamp()
     with litani.atomic_write(args.status_file) as handle:
         print(json.dumps(out_data, indent=2), file=handle)
 
@@ -126,7 +126,7 @@ async def exec_job(args):
             "\n".join([l.rstrip() for l in out_data["stderr"]]),
             file=sys.stderr)
 
-    lib.util.timestamp("end_time", out_data)
+    out_data["end_time"] = lib.util.timestamp()
     out_str = json.dumps(out_data, indent=2)
     logging.debug("run status: %s", out_str)
     with litani.atomic_write(args.status_file) as handle:

--- a/lib/init.py
+++ b/lib/init.py
@@ -108,7 +108,7 @@ async def init(args):
             f"file://{str(latest_symlink)}/html/index.html")
 
     now = datetime.datetime.now(datetime.timezone.utc).strftime(
-        litani.TIME_FORMAT_W)
+        litani.TIME_FORMAT_R)
 
     with litani.atomic_write(cache_dir / litani.CACHE_FILE) as handle:
         print(json.dumps({

--- a/lib/litani.py
+++ b/lib/litani.py
@@ -26,10 +26,14 @@ import uuid
 CACHE_FILE = "cache.json"
 CACHE_POINTER = ".litani_cache_dir"
 DEFAULT_STAGES = ["build", "test", "report"]
+INCREMENTAL = "incremental"
+FINAL = "final"
+BUILD_ARTIFACTS = "BuildArtifacts"
 ENV_VAR_JOB_ID = "LITANI_JOB_ID"
 JOBS_DIR = "jobs"
 RUN_FILE = "run.json"
 TIME_FORMAT_R = "%Y-%m-%dT%H:%M:%SZ"
+TIME_FORMAT_FILENAME_FRIENDLY = "%Y-%m-%dT%H-%M-%SZ"
 TIME_FORMAT_MS = "%Y-%m-%dT%H:%M:%S.%fZ"
 VERSION_MAJOR = 1
 VERSION_MINOR = 27
@@ -196,6 +200,12 @@ def get_cache_dir(path=os.getcwd()):
         return CacheDir.get(path)
     except FileNotFoundError:
         sys.exit(1)
+
+
+def get_run_id():
+    with open(get_cache_dir() / CACHE_FILE) as handle:
+        cache = json.load(handle)
+        return cache["run_id"]
 
 
 def get_report_dir():

--- a/lib/litani.py
+++ b/lib/litani.py
@@ -30,7 +30,6 @@ ENV_VAR_JOB_ID = "LITANI_JOB_ID"
 JOBS_DIR = "jobs"
 RUN_FILE = "run.json"
 TIME_FORMAT_R = "%Y-%m-%dT%H:%M:%SZ"
-TIME_FORMAT_W = "%Y-%m-%dT%H:%M:%SZ"
 TIME_FORMAT_MS = "%Y-%m-%dT%H:%M:%S.%fZ"
 VERSION_MAJOR = 1
 VERSION_MINOR = 27

--- a/lib/render.py
+++ b/lib/render.py
@@ -17,11 +17,11 @@ import time
 import traceback
 
 
-from lib import litani_report, litani
+from lib import aws_s3, litani, litani_report
 import lib.validation
 
 
-def continuous_render_report(cache_dir, killer, out_file, render):
+def continuous_render_report(cache_dir, killer, out_file, render, bucket_name):
     try:
         while True:
             run = litani_report.get_run_data(cache_dir)
@@ -34,6 +34,8 @@ def continuous_render_report(cache_dir, killer, out_file, render):
             render(run)
             if killer.is_set():
                 break
+            if bucket_name:
+                aws_s3.sync(bucket_name, cache_dir, litani.INCREMENTAL)
             time.sleep(2)
     except BaseException as e:
         logging.error("Continuous render function crashed")

--- a/lib/run_build.py
+++ b/lib/run_build.py
@@ -11,7 +11,6 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License
 
-import datetime
 import itertools
 import json
 import logging
@@ -179,12 +178,9 @@ async def run_build(args):
     signal.signal(lib.run_printer.DUMP_SIGNAL, sig_handler)
     runner.run()
 
-    now = datetime.datetime.now(datetime.timezone.utc).strftime(
-        litani.TIME_FORMAT_W)
-
     with open(cache_dir / litani.CACHE_FILE) as handle:
         run_info = json.load(handle)
-    run_info["end_time"] = now
+    run_info["end_time"] = lib.util.timestamp()
     run_info["parallelism"] = runner.get_parallelism_graph()
 
     success = True

--- a/lib/util.py
+++ b/lib/util.py
@@ -20,9 +20,8 @@ import sys
 from lib import litani
 
 
-def timestamp(key, data):
-    data[key] = datetime.datetime.now(datetime.timezone.utc).strftime(
-        litani.TIME_FORMAT_W)
+def timestamp(format=litani.TIME_FORMAT_R):
+    return datetime.datetime.now(datetime.timezone.utc).strftime(format)
 
 
 def get_pools(args):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A new flag has been added to the `run-build` command that enables the uploading of artifacts to a specified S3 bucket.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
