### PR TITLE
Modify behavior of acquire-html-dir command

### DIFF
--- a/lib/litani.py
+++ b/lib/litani.py
@@ -58,6 +58,22 @@ class ExpireableDirectory:
 
 
 
+class ReportRendering:
+    """This class is to mark the completion of the report rendering process"""
+
+    def __init__(self):
+        self._touchfile = get_cache_dir().resolve() / ".litani-completed"
+
+
+    def complete(self):
+        self._touchfile.touch()
+
+
+    def has_completed(self):
+        return self._touchfile.exists()
+
+
+
 class AcquisitionFailed(Exception):
     pass
 

--- a/lib/run_build.py
+++ b/lib/run_build.py
@@ -213,6 +213,9 @@ async def run_build(args):
         with litani.atomic_write(args.out_file) as handle:
             print(json.dumps(run, indent=2), file=handle)
 
+    report_rendering = litani.ReportRendering()
+    report_rendering.complete()
+
     # Print the path to the complete report at the end of 'litani run-build'.
     # The same path was printed at the start of 'litani init'.
     if 'latest_symlink' in run_info:


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

If a build has finished, then a lock will not be acquired (and consequently the path to the HTML directory will not be printed to stdout) until the report has finished rendering.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
