### PR TITLE
Add flag to disable rendering of reports

### DIFF
--- a/doc/src/man/litani-run-build.scdoc
+++ b/doc/src/man/litani-run-build.scdoc
@@ -16,6 +16,7 @@ litani run-build - Start a Litani run
 	\[*-o*/*--out-file* _F_]
 	\[*--fail-on-pipeline-failure*]
 	\[*--no-pipeline-dep-graph*]
+	\[*--no-report-render*]
 	\[*-p*/*--pipelines* _P_ [_P_ ...]]
 	\[*-s*/*--ci-stage* _S_]
 
@@ -55,6 +56,9 @@ parallel.
 	Do not render dependency graphs for each pipeline onto the HTML individual
 	pipeline pages. Pipeline graphs will also not be rendered if Graphviz is
 	not installed.
+
+*--no-report-render*
+	Do not render the HTML report.
 
 *-p* _P_ [_P_ ...], *--pipelines* _P_ [_P_ ...]
 	Only run jobs that are part of the specified pipelines.

--- a/lib/init.py
+++ b/lib/init.py
@@ -104,8 +104,8 @@ async def init(args):
 
     if not args.no_print_out_dir:
         print(
-            "Report will be rendered at "
-            f"file://{str(latest_symlink)}/html/index.html")
+            "Build outputs will be present at this directory: "
+            f"file://{str(latest_symlink)}")
 
     now = datetime.datetime.now(datetime.timezone.utc).strftime(
         litani.TIME_FORMAT_W)

--- a/lib/litani_report.py
+++ b/lib/litani_report.py
@@ -455,6 +455,8 @@ async def acquire_html_dir(args):
         end = datetime.datetime.max
     while datetime.datetime.now() <= end:
         html_dir = lib.litani.get_report_dir().resolve()
+        if not html_dir.exists():
+            sys.exit(1)
         lockable_dir = lib.litani.LockableDirectory(html_dir)
         if not lockable_dir.acquire():
             await asyncio.sleep(1)

--- a/test/e2e/run
+++ b/test/e2e/run
@@ -78,6 +78,22 @@ def check_run(_, run_dir, mod):
         sys.exit(1)
 
 
+def check_no_report_render(_, run_dir, mod):
+    os.chdir(run_dir)
+    does_html_dir_exist = False
+    for child in (run_dir / "output").iterdir():
+        if child.is_dir() and child.name == "html":
+            does_html_dir_exist = True
+            break
+    should_not_render_report = mod.check_no_report_render()
+    unexpected_html_dir_was_created = should_not_render_report \
+        and does_html_dir_exist
+    expected_html_dir_was_not_created = not should_not_render_report \
+        and not does_html_dir_exist
+    if unexpected_html_dir_was_created or expected_html_dir_was_not_created:
+        sys.exit(1)
+
+
 def add_jobs(litani, run_dir, mod):
     os.chdir(run_dir)
     jobs = mod.get_jobs()
@@ -174,6 +190,7 @@ OPERATIONS = {
     "add-jobs": add_jobs,
     "run-build": run_build,
     "check-run": check_run,
+    "check-no-report-render": check_no_report_render,
     "transform-jobs": transform_jobs,
     "get-jobs": get_jobs,
     "set-jobs": set_jobs,

--- a/test/e2e/tests/no_report_render.py
+++ b/test/e2e/tests/no_report_render.py
@@ -1,0 +1,57 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+SLOW = False
+
+
+def get_init_args():
+    return {
+        "kwargs": {
+            "project": "test_no_report_render",
+        }
+    }
+
+
+def get_jobs():
+    jobs = []
+    jobs.append({
+        "kwargs": {
+            "command": "/usr/bin/false",
+            "ci-stage": "build",
+            "pipeline": "job fails",
+        }
+    })
+    jobs.append({
+        "kwargs": {
+            "command": "/usr/bin/true",
+            "ci-stage": "build",
+            "pipeline": "job succeeds",
+        }
+    })
+    return jobs
+
+
+def get_run_build_args():
+    return {
+        "args": [
+            "no-report-render",
+        ]
+    }
+
+
+def check_run(run):
+    return True
+
+
+def check_no_report_render():
+    return True

--- a/test/e2e/tests/report_render.py
+++ b/test/e2e/tests/report_render.py
@@ -1,0 +1,53 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+SLOW = False
+
+
+def get_init_args():
+    return {
+        "kwargs": {
+            "project": "test_report_render",
+        }
+    }
+
+
+def get_jobs():
+    jobs = []
+    jobs.append({
+        "kwargs": {
+            "command": "/usr/bin/false",
+            "ci-stage": "build",
+            "pipeline": "job fails",
+        }
+    })
+    jobs.append({
+        "kwargs": {
+            "command": "/usr/bin/true",
+            "ci-stage": "build",
+            "pipeline": "job succeeds",
+        }
+    })
+    return jobs
+
+
+def get_run_build_args():
+    return {}
+
+
+def check_run(run):
+    return True
+
+
+def check_no_report_render():
+    return False

--- a/test/run
+++ b/test/run
@@ -255,6 +255,23 @@ def add_e2e_tests(test_dir, output_dir, fast, queue, litani):
             timeout=timeout)
 
 
+        if test_has_method("check_no_report_render"):
+            enqueue_job(
+                queue,
+                command=collapse(f"""
+                    {e2e_test_dir / 'run'}
+                    --test-file {test_file}
+                    --litani {litani}
+                    --run-dir {run_dir}
+                    --operation check-no-report-render"""),
+                pipeline=f"e2e_{test_file.stem}",
+                ci_stage="test",
+                description=f"{test_file.stem}: check report rendering",
+                inputs=f"{run_dir}/output/run.json",
+                cwd=run_dir,
+                timeout=timeout)
+
+
 def add_unit_tests(test_dir, root_dir, queue):
     for fyle in (test_dir / "unit").iterdir():
         if fyle.name in ["__init__.py", "__pycache__"]:


### PR DESCRIPTION
*Issue #, if available:*
~~#17~~

*Description of changes:*

This PR introduces a new flag `--no-report-render` for the `run-build` command that turns off the rendering of the HTML report.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
