### PR TITLE
Use `dataclasses.field` for `default_factory`

### DIFF
--- a/lib/ninja.py
+++ b/lib/ninja.py
@@ -137,7 +137,7 @@ class Runner:
     pipelines: list
     ci_stage: str
     proc: subprocess.CompletedProcess = None
-    status_parser: _StatusParser = _StatusParser()
+    status_parser: _StatusParser = = dataclasses.field(default_factory=_StatusParser)
     out_acc: _OutputAccumulator = None
 
 

--- a/lib/ninja.py
+++ b/lib/ninja.py
@@ -137,7 +137,7 @@ class Runner:
     pipelines: list
     ci_stage: str
     proc: subprocess.CompletedProcess = None
-    status_parser: _StatusParser = = dataclasses.field(default_factory=_StatusParser)
+    status_parser: _StatusParser = dataclasses.field(default_factory=_StatusParser)
     out_acc: _OutputAccumulator = None
 
 


### PR DESCRIPTION
https://docs.python.org/3/library/dataclasses.html#dataclasses.field

This is necessary for compatibility with Python 3.11. See https://github.com/Homebrew/homebrew-core/pull/119040#issuecomment-1365308458