### PR TITLE
Add fractional seconds duration to run.json

### DIFF
--- a/lib/validation.py
+++ b/lib/validation.py
@@ -392,6 +392,9 @@ def _run_schema():
                     "stdout": voluptuous.Any([str], None),
                     # A list of strings that the command printed to its stdout.
 
+                    "duration_ms": voluptuous.Any(str, None),
+                    # Duration of this job S.MS
+
                     "duration_str": voluptuous.Any(str, None),
                     # A human-readable duration of this job (HH:MM:SS).
 


### PR DESCRIPTION
Litani now measures the runtime of each job in fractional seconds and records this information in the "duration_ms" field in run.json.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
